### PR TITLE
Add header settings toggle for API configuration

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -14,6 +14,12 @@ const modelLogTemplate = document.getElementById('model-log-item-template');
 const pptSlideTemplate = document.getElementById('ppt-slide-template');
 const configForm = document.getElementById('config-form');
 const configStatus = document.getElementById('config-status');
+const settingsToggle = document.getElementById('settings-toggle');
+const settingsOverlay = document.getElementById('settings-overlay');
+const settingsDrawer = settingsOverlay?.querySelector('.settings-drawer') ?? null;
+const settingsCloseButtons = document.querySelectorAll('[data-action="close-settings"]');
+
+let previousFocusedElement = null;
 
 const SERVICES = ['chat', 'image', 'speech', 'sound_effects', 'asr'];
 const serviceInputs = SERVICES.reduce((acc, service) => {
@@ -29,6 +35,67 @@ let currentWebPreview = null;
 let currentPptSlides = [];
 let isCarouselMode = false;
 const modelLogs = [];
+
+function openSettingsPanel() {
+  if (!settingsOverlay || !settingsToggle) return;
+  if (!settingsOverlay.hidden) return;
+
+  previousFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  settingsOverlay.hidden = false;
+  document.body?.classList.add('no-scroll');
+  settingsToggle.setAttribute('aria-expanded', 'true');
+
+  const firstInput = configForm?.querySelector('input, select, textarea, button');
+  if (firstInput instanceof HTMLElement) {
+    firstInput.focus();
+  } else if (settingsDrawer instanceof HTMLElement) {
+    settingsDrawer.focus();
+  }
+}
+
+function closeSettingsPanel() {
+  if (!settingsOverlay || !settingsToggle) return;
+  if (settingsOverlay.hidden) return;
+
+  settingsOverlay.hidden = true;
+  document.body?.classList.remove('no-scroll');
+  settingsToggle.setAttribute('aria-expanded', 'false');
+
+  const focusTarget = previousFocusedElement instanceof HTMLElement ? previousFocusedElement : settingsToggle;
+  previousFocusedElement = null;
+  if (focusTarget instanceof HTMLElement) {
+    focusTarget.focus();
+  }
+}
+
+if (settingsToggle && settingsOverlay) {
+  settingsToggle.addEventListener('click', () => {
+    if (settingsOverlay.hidden) {
+      openSettingsPanel();
+    } else {
+      closeSettingsPanel();
+    }
+  });
+}
+
+settingsCloseButtons.forEach((button) => {
+  button.addEventListener('click', closeSettingsPanel);
+});
+
+if (settingsOverlay) {
+  settingsOverlay.addEventListener('click', (event) => {
+    if (event.target === settingsOverlay) {
+      closeSettingsPanel();
+    }
+  });
+}
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && !settingsOverlay?.hidden) {
+    event.preventDefault();
+    closeSettingsPanel();
+  }
+});
 
 function addMessage(role, text) {
   const message = document.createElement('article');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,7 +22,19 @@
             <p>以对话驱动的多模态内容生成体验</p>
           </div>
         </div>
-        <div class="status-pill" id="status-pill">待命中…</div>
+        <div class="header-actions">
+          <div class="status-pill" id="status-pill">待命中…</div>
+          <button
+            type="button"
+            class="settings-toggle"
+            id="settings-toggle"
+            aria-haspopup="dialog"
+            aria-expanded="false"
+          >
+            <span aria-hidden="true">⚙️</span>
+            <span>服务配置</span>
+          </button>
+        </div>
       </header>
 
       <main class="app-main">
@@ -41,99 +53,6 @@
         </section>
 
         <aside class="insight-panel">
-          <section class="insight-card settings-card">
-            <div class="settings-header">
-              <h2>模型配置</h2>
-              <p>为聊天、图像、语音与音频工具填写推理端点信息。</p>
-            </div>
-            <form class="config-form" id="config-form">
-              <fieldset class="config-group">
-                <legend>聊天模型</legend>
-                <label>
-                  模型 ID
-                  <input type="text" data-service="chat" data-field="model" placeholder="moonshot-chat" />
-                </label>
-                <label>
-                  Base URL
-                  <input type="url" data-service="chat" data-field="base_url" placeholder="https://api.example.com/v1/chat" />
-                </label>
-                <label>
-                  API Key
-                  <input type="password" data-service="chat" data-field="api_key" placeholder="••••••" autocomplete="off" />
-                </label>
-              </fieldset>
-
-              <fieldset class="config-group">
-                <legend>图像生成</legend>
-                <label>
-                  模型 ID
-                  <input type="text" data-service="image" data-field="model" placeholder="moonshot-image" />
-                </label>
-                <label>
-                  Base URL
-                  <input type="url" data-service="image" data-field="base_url" placeholder="https://api.example.com/v1/images" />
-                </label>
-                <label>
-                  API Key
-                  <input type="password" data-service="image" data-field="api_key" placeholder="••••••" autocomplete="off" />
-                </label>
-              </fieldset>
-
-              <fieldset class="config-group">
-                <legend>语音合成</legend>
-                <label>
-                  模型 ID
-                  <input type="text" data-service="speech" data-field="model" placeholder="moonshot-tts" />
-                </label>
-                <label>
-                  Base URL
-                  <input type="url" data-service="speech" data-field="base_url" placeholder="https://api.example.com/v1/speech" />
-                </label>
-                <label>
-                  API Key
-                  <input type="password" data-service="speech" data-field="api_key" placeholder="••••••" autocomplete="off" />
-                </label>
-              </fieldset>
-
-              <fieldset class="config-group">
-                <legend>音效生成</legend>
-                <label>
-                  模型 ID
-                  <input type="text" data-service="sound_effects" data-field="model" placeholder="moonshot-sfx" />
-                </label>
-                <label>
-                  Base URL
-                  <input type="url" data-service="sound_effects" data-field="base_url" placeholder="https://api.example.com/v1/sfx" />
-                </label>
-                <label>
-                  API Key
-                  <input type="password" data-service="sound_effects" data-field="api_key" placeholder="••••••" autocomplete="off" />
-                </label>
-              </fieldset>
-
-              <fieldset class="config-group">
-                <legend>语音识别</legend>
-                <label>
-                  模型 ID
-                  <input type="text" data-service="asr" data-field="model" placeholder="moonshot-asr" />
-                </label>
-                <label>
-                  Base URL
-                  <input type="url" data-service="asr" data-field="base_url" placeholder="https://api.example.com/v1/asr" />
-                </label>
-                <label>
-                  API Key
-                  <input type="password" data-service="asr" data-field="api_key" placeholder="••••••" autocomplete="off" />
-                </label>
-              </fieldset>
-
-              <div class="config-actions">
-                <span class="config-status" id="config-status" role="status"></span>
-                <button type="submit" class="primary-button">保存配置</button>
-              </div>
-            </form>
-          </section>
-
           <section class="insight-card">
             <h2>当前模型调用</h2>
             <ul class="model-log" id="model-log"></ul>
@@ -169,6 +88,118 @@
           </section>
         </aside>
       </main>
+    </div>
+
+    <div class="settings-overlay" id="settings-overlay" hidden>
+      <div
+        class="settings-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settings-title"
+        tabindex="-1"
+      >
+        <div class="settings-drawer-header">
+          <div class="settings-header">
+            <h2 id="settings-title">模型配置</h2>
+            <p>为聊天、图像、语音与音频工具填写推理端点信息。</p>
+          </div>
+          <button
+            type="button"
+            class="ghost-button settings-close"
+            data-action="close-settings"
+            aria-label="关闭配置面板"
+          >
+            关闭
+          </button>
+        </div>
+
+        <form class="config-form" id="config-form">
+          <fieldset class="config-group">
+            <legend>聊天模型</legend>
+            <label>
+              模型 ID
+              <input type="text" data-service="chat" data-field="model" placeholder="moonshot-chat" />
+            </label>
+            <label>
+              Base URL
+              <input type="url" data-service="chat" data-field="base_url" placeholder="https://api.example.com/v1/chat" />
+            </label>
+            <label>
+              API Key
+              <input type="password" data-service="chat" data-field="api_key" placeholder="••••••" autocomplete="off" />
+            </label>
+          </fieldset>
+
+          <fieldset class="config-group">
+            <legend>图像生成</legend>
+            <label>
+              模型 ID
+              <input type="text" data-service="image" data-field="model" placeholder="moonshot-image" />
+            </label>
+            <label>
+              Base URL
+              <input type="url" data-service="image" data-field="base_url" placeholder="https://api.example.com/v1/images" />
+            </label>
+            <label>
+              API Key
+              <input type="password" data-service="image" data-field="api_key" placeholder="••••••" autocomplete="off" />
+            </label>
+          </fieldset>
+
+          <fieldset class="config-group">
+            <legend>语音合成</legend>
+            <label>
+              模型 ID
+              <input type="text" data-service="speech" data-field="model" placeholder="moonshot-tts" />
+            </label>
+            <label>
+              Base URL
+              <input type="url" data-service="speech" data-field="base_url" placeholder="https://api.example.com/v1/speech" />
+            </label>
+            <label>
+              API Key
+              <input type="password" data-service="speech" data-field="api_key" placeholder="••••••" autocomplete="off" />
+            </label>
+          </fieldset>
+
+          <fieldset class="config-group">
+            <legend>音效生成</legend>
+            <label>
+              模型 ID
+              <input type="text" data-service="sound_effects" data-field="model" placeholder="moonshot-sfx" />
+            </label>
+            <label>
+              Base URL
+              <input type="url" data-service="sound_effects" data-field="base_url" placeholder="https://api.example.com/v1/sfx" />
+            </label>
+            <label>
+              API Key
+              <input type="password" data-service="sound_effects" data-field="api_key" placeholder="••••••" autocomplete="off" />
+            </label>
+          </fieldset>
+
+          <fieldset class="config-group">
+            <legend>语音识别</legend>
+            <label>
+              模型 ID
+              <input type="text" data-service="asr" data-field="model" placeholder="moonshot-asr" />
+            </label>
+            <label>
+              Base URL
+              <input type="url" data-service="asr" data-field="base_url" placeholder="https://api.example.com/v1/asr" />
+            </label>
+            <label>
+              API Key
+              <input type="password" data-service="asr" data-field="api_key" placeholder="••••••" autocomplete="off" />
+            </label>
+          </fieldset>
+
+          <div class="config-actions">
+            <span class="config-status" id="config-status" role="status"></span>
+            <button type="submit" class="primary-button">保存配置</button>
+          </div>
+        </form>
+      </div>
     </div>
 
     <template id="model-log-item-template">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -26,6 +26,10 @@ body {
   justify-content: center;
 }
 
+body.no-scroll {
+  overflow: hidden;
+}
+
 .app-shell {
   width: min(1200px, 100%);
   display: flex;
@@ -50,6 +54,12 @@ body {
   display: flex;
   align-items: center;
   gap: 1rem;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .logo {
@@ -88,6 +98,39 @@ body {
 .status-pill[data-busy='true'] {
   background: var(--accent);
   color: white;
+}
+
+.settings-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.5rem 1.05rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+}
+
+.settings-toggle:hover,
+.settings-toggle:focus-visible {
+  background: white;
+  box-shadow: 0 16px 28px -28px rgba(15, 23, 42, 0.6);
+}
+
+.settings-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.settings-toggle[aria-expanded='true'] {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+  box-shadow: 0 20px 35px -24px rgba(79, 70, 229, 0.8);
 }
 
 .app-main {
@@ -306,6 +349,56 @@ body {
 .insight-panel {
   position: sticky;
   top: 2rem;
+}
+
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  justify-content: flex-end;
+  padding: clamp(1rem, 4vw, 2rem);
+  background: rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(4px);
+}
+
+.settings-overlay[hidden] {
+  display: none;
+}
+
+.settings-drawer {
+  width: min(420px, 100%);
+  max-height: 100%;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  box-shadow: 0 28px 60px -40px rgba(15, 23, 42, 0.65);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  overflow: auto;
+}
+
+.settings-drawer-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.settings-close {
+  white-space: nowrap;
+}
+
+@media (max-width: 900px) {
+  .settings-overlay {
+    justify-content: center;
+  }
+
+  .settings-drawer {
+    width: min(520px, 100%);
+  }
 }
 
 .insight-card {


### PR DESCRIPTION
## Summary
- add a top-right settings toggle that opens the API configuration drawer so the main layout stays uncluttered
- update frontend logic and styles to support the overlay drawer with focus management and responsive sizing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68deb674cd3c83219cefe2080db2169b