### PR TITLE
Add API and configuration regression tests

### DIFF
--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -1,0 +1,145 @@
+import copy
+
+import pytest
+
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient
+
+import okcvm.config as config_mod
+from okcvm.config import MediaConfig, ModelEndpointConfig
+from okcvm.api import main
+
+
+@pytest.fixture(autouse=True)
+def restore_config_state():
+    """Ensure global configuration is restored after each test."""
+    original = config_mod.get_config()
+    try:
+        yield
+    finally:
+        with config_mod._config_lock:  # type: ignore[attr-defined]
+            config_mod._config = config_mod.AppConfig(  # type: ignore[attr-defined]
+                chat=copy.deepcopy(original.chat),
+                media=copy.deepcopy(original.media),
+            )
+
+
+@pytest.fixture
+def client():
+    return TestClient(main.create_app())
+
+
+def test_root_redirects_to_frontend(client):
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code in {302, 307}
+    assert response.headers["location"] == "/ui/"
+
+
+def test_read_config_endpoint_returns_current_settings(client):
+    image = ModelEndpointConfig(
+        model="image-alpha",
+        base_url="https://api.example.com/image",
+        api_key="secret-image",
+    )
+    chat = ModelEndpointConfig(
+        model="gpt-test",
+        base_url="https://api.example.com/chat",
+        api_key="secret-chat",
+    )
+    config_mod.configure(
+        chat=chat,
+        media=MediaConfig(
+            image=image,
+            speech=None,
+            sound_effects=None,
+            asr=None,
+        ),
+    )
+
+    response = client.get("/api/config")
+    payload = response.json()
+
+    assert payload["chat"]["model"] == "gpt-test"
+    assert payload["chat"]["base_url"] == "https://api.example.com/chat"
+    assert payload["chat"]["api_key_present"] is True
+    assert payload["image"]["model"] == "image-alpha"
+    assert payload["image"]["api_key_present"] is True
+    assert payload["speech"] is None
+    assert payload["sound_effects"] is None
+    assert payload["asr"] is None
+
+
+def test_update_config_endpoint_accepts_trimmed_payload(client):
+    response = client.post(
+        "/api/config",
+        json={
+            "chat": {
+                "model": "  gpt-4o-mini  ",
+                "base_url": " https://chat.invalid/v1 ",
+                "api_key": " sk-live ",
+            },
+            "image": {
+                "model": "  painterly ",
+                "base_url": " https://image.invalid/v1 ",
+            },
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["chat"]["model"] == "gpt-4o-mini"
+    assert payload["chat"]["base_url"] == "https://chat.invalid/v1"
+    assert payload["chat"]["api_key_present"] is True
+    assert payload["image"]["model"] == "painterly"
+    assert payload["image"]["base_url"] == "https://image.invalid/v1"
+
+    updated = config_mod.get_config()
+    assert updated.chat is not None
+    assert updated.chat.model == "gpt-4o-mini"
+    assert updated.media.image is not None
+    assert updated.media.image.base_url == "https://image.invalid/v1"
+
+
+def test_update_config_endpoint_reports_errors(monkeypatch, client):
+    def boom(**kwargs):  # noqa: ANN001
+        raise RuntimeError("bad config")
+
+    monkeypatch.setattr(main, "configure", boom)
+
+    response = client.post(
+        "/api/config",
+        json={"chat": {"model": "gpt", "base_url": "https://chat.invalid"}},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "bad config"
+
+
+def test_session_endpoints_use_session_state(monkeypatch, client):
+    boot = client.get("/api/session/boot")
+    boot_payload = boot.json()
+    assert "reply" in boot_payload
+    assert "vm" in boot_payload
+    assert boot_payload["vm"]["history_length"] >= 0
+
+    captured = {}
+
+    def fake_respond(message):  # noqa: ANN001
+        captured["message"] = message
+        return {
+            "reply": "pong",
+            "meta": {"model": "stub"},
+            "web_preview": None,
+            "ppt_slides": [],
+            "vm_history": [],
+        }
+
+    monkeypatch.setattr(main.state, "respond", fake_respond)
+
+    chat = client.post("/api/chat", json={"message": "ping"})
+    assert chat.status_code == 200
+    assert chat.json()["reply"] == "pong"
+    assert captured["message"] == "ping"
+
+    info = client.get("/api/session/info")
+    assert info.status_code == 200
+    assert "system_prompt" in info.json()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,119 @@
+import copy
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+import okcvm.config as config_mod
+from okcvm.config import MediaConfig, ModelEndpointConfig
+
+
+@pytest.fixture(autouse=True)
+def restore_config_state():
+    original = config_mod.get_config()
+    try:
+        yield
+    finally:
+        with config_mod._config_lock:  # type: ignore[attr-defined]
+            config_mod._config = config_mod.AppConfig(  # type: ignore[attr-defined]
+                chat=copy.deepcopy(original.chat),
+                media=copy.deepcopy(original.media),
+            )
+
+
+def test_model_endpoint_config_from_env_with_partial_values():
+    env = {
+        "OKCVM_IMAGE_MODEL": "stable-pixel",
+        "OKCVM_IMAGE_BASE_URL": "https://image.api",
+    }
+    cfg = ModelEndpointConfig.from_env("OKCVM_IMAGE", env)
+    assert cfg is not None
+    assert cfg.model == "stable-pixel"
+    assert cfg.base_url == "https://image.api"
+    assert cfg.api_key is None
+
+    missing = ModelEndpointConfig.from_env("OKCVM_SPEECH", env)
+    assert missing is None
+
+
+def test_model_endpoint_config_describe_hides_api_key():
+    cfg = ModelEndpointConfig(
+        model="speech-pro",
+        base_url="https://speech.api",
+        api_key="top-secret",
+    )
+    description = cfg.describe()
+    assert description == {
+        "model": "speech-pro",
+        "base_url": "https://speech.api",
+        "api_key_present": True,
+    }
+
+
+def test_configure_updates_media_without_affecting_chat():
+    initial_chat = ModelEndpointConfig(
+        model="gpt-initial",
+        base_url="https://chat.initial",
+        api_key="initial",
+    )
+    config_mod.configure(chat=initial_chat)
+
+    media = MediaConfig(
+        image=ModelEndpointConfig(
+            model="img-one",
+            base_url="https://image.one",
+            api_key="image-key",
+        ),
+    )
+    config_mod.configure(media=media)
+
+    cfg = config_mod.get_config()
+    assert cfg.chat is not None
+    assert cfg.chat.model == "gpt-initial"
+    assert cfg.media.image is not None
+    assert cfg.media.image.model == "img-one"
+
+
+def test_load_config_from_yaml_supports_env_keys(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("CHAT_API_KEY", "sk-chat")
+    monkeypatch.setenv("SPEECH_API_KEY", "sk-speech")
+
+    payload = {
+        "chat": {
+            "model": "gpt-yaml",
+            "base_url": "https://chat.yaml",
+            "api_key_env": "CHAT_API_KEY",
+        },
+        "media": {
+            "image": {
+                "model": "image-yaml",
+                "base_url": "https://image.yaml",
+                "api_key": "inline-image",
+            },
+            "speech": {
+                "model": "speech-yaml",
+                "base_url": "https://speech.yaml",
+                "api_key_env": "SPEECH_API_KEY",
+            },
+        },
+    }
+
+    config_file = tmp_path / "okcvm.yaml"
+    config_file.write_text(config_mod.yaml.safe_dump(payload), encoding="utf-8")
+
+    config_mod.load_config_from_yaml(config_file)
+    cfg = config_mod.get_config()
+
+    assert cfg.chat is not None
+    assert cfg.chat.api_key == "sk-chat"
+    assert cfg.media.image is not None
+    assert cfg.media.image.api_key == "inline-image"
+    assert cfg.media.speech is not None
+    assert cfg.media.speech.api_key == "sk-speech"
+
+
+def test_load_config_from_yaml_missing_file_is_noop(tmp_path: Path, capsys):
+    config_mod.load_config_from_yaml(tmp_path / "missing.yaml")
+    captured = capsys.readouterr().out
+    assert "Config file not found" in captured

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,121 @@
+import copy
+import os
+import sys
+import types
+
+import pytest
+
+pytest.importorskip("langchain_openai")
+pytest.importorskip("langchain_core")
+
+import okcvm.config as config_mod
+from okcvm import ToolRegistry
+from okcvm.config import ModelEndpointConfig
+from okcvm.llm import create_llm_chain
+
+
+@pytest.fixture(autouse=True)
+def restore_config_state():
+    original = config_mod.get_config()
+    try:
+        yield
+    finally:
+        with config_mod._config_lock:  # type: ignore[attr-defined]
+            config_mod._config = config_mod.AppConfig(  # type: ignore[attr-defined]
+                chat=copy.deepcopy(original.chat),
+                media=copy.deepcopy(original.media),
+            )
+
+
+def test_create_llm_chain_uses_config(monkeypatch):
+    class DummyTool:
+        def __init__(self, name):
+            self.name = name
+            self.description = "dummy"
+
+    def fake_get_langchain_tools(self):  # noqa: ANN001
+        return [DummyTool("tool-a"), DummyTool("tool-b")]
+
+    monkeypatch.setattr(ToolRegistry, "get_langchain_tools", fake_get_langchain_tools, raising=False)
+
+    captured = {}
+
+    class DummyChat:
+        def __init__(self, **kwargs):
+            captured["chat_kwargs"] = kwargs
+
+        def bind_tools(self, tools):  # noqa: ANN001
+            captured["bound_tools"] = tools
+            return ("bound", tools)
+
+    dummy_agents = types.ModuleType("langchain.agents")
+
+    def fake_create_agent(llm_with_tools, tools, prompt):  # noqa: ANN001
+        captured["llm_with_tools"] = llm_with_tools
+        captured["agent_tools"] = tools
+        captured["prompt"] = prompt
+        return {"agent": "ok"}
+
+    class DummyExecutor:
+        def __init__(self, agent, tools, verbose):  # noqa: ANN001
+            captured["executor_agent"] = agent
+            captured["executor_tools"] = tools
+            captured["executor_verbose"] = verbose
+
+        def invoke(self, payload):  # pragma: no cover - not used in this test
+            return payload
+
+    dummy_agents.create_tool_calling_agent = fake_create_agent
+    dummy_agents.AgentExecutor = DummyExecutor
+    monkeypatch.setitem(sys.modules, "langchain.agents", dummy_agents)
+    import okcvm.llm as llm_mod
+
+    monkeypatch.setattr(llm_mod, "ChatOpenAI", DummyChat)
+
+    config_mod.configure(
+        chat=ModelEndpointConfig(
+            model="gpt-sim",
+            base_url="https://chat.sim",
+            api_key="sk-sim",
+        )
+    )
+
+    registry = ToolRegistry.from_default_spec()
+    chain = create_llm_chain(registry)
+
+    assert captured["chat_kwargs"] == {
+        "model": "gpt-sim",
+        "api_key": "sk-sim",
+        "base_url": "https://chat.sim",
+        "temperature": 0.7,
+        "streaming": False,
+    }
+    assert len(captured["bound_tools"][1]) == 2
+    assert captured["executor_verbose"] is True
+    assert isinstance(chain, DummyExecutor)
+
+
+@pytest.mark.requires_api
+@pytest.mark.skipif(
+    not (
+        os.getenv("OKCVM_CHAT_MODEL")
+        and os.getenv("OKCVM_CHAT_BASE_URL")
+        and os.getenv("OKCVM_CHAT_API_KEY")
+    ),
+    reason="Requires OKCVM_CHAT_* environment variables for live API call.",
+)
+def test_create_llm_chain_with_live_api(monkeypatch):
+    monkeypatch.setattr(ToolRegistry, "get_langchain_tools", lambda self: [], raising=False)
+
+    config_mod.configure(
+        chat=ModelEndpointConfig(
+            model=os.environ["OKCVM_CHAT_MODEL"],
+            base_url=os.environ["OKCVM_CHAT_BASE_URL"],
+            api_key=os.environ["OKCVM_CHAT_API_KEY"],
+        )
+    )
+
+    registry = ToolRegistry.from_default_spec()
+    chain = create_llm_chain(registry)
+    response = chain.invoke({"input": "Say 'integration test' and nothing else.", "history": []})
+    assert "integration test" in response.get("output", "").lower()


### PR DESCRIPTION
## Summary
- add FastAPI integration tests covering configuration endpoints and session lifecycle
- extend configuration tests to validate environment-driven YAML loading and endpoint metadata
- exercise LLM chain factory with both mocked and live (opt-in) API scenarios

## Testing
- pytest tests/test_api_app.py tests/test_config.py tests/test_llm.py -k "not live_api"

------
https://chatgpt.com/codex/tasks/task_b_68df2a0fe1608321b9c563facdb0bb68