### PR TITLE
Add centralized logging for FastAPI server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/okcvm.egg-info/
 .idea
 .venv
 uv.lock
+logs/

--- a/src/okcvm/api/main.py
+++ b/src/okcvm/api/main.py
@@ -3,25 +3,31 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
 from ..config import ModelEndpointConfig, configure, get_config
+from ..logging_utils import get_logger, setup_logging
 from ..session import SessionState
 from .models import ChatRequest, ConfigUpdatePayload, build_media_config
 
 # --- Frontend Setup ---
 FRONTEND_DIR = Path(__file__).resolve().parents[3] / "frontend"
 
+setup_logging()
+logger = get_logger(__name__)
+
 
 def _ensure_frontend() -> None:
     if not FRONTEND_DIR.exists():  # pragma: no cover - developer misconfiguration
-        raise RuntimeError(
+        message = (
             "The frontend directory could not be located. Expected path: "
             f"{FRONTEND_DIR}"
         )
+        logger.error(message)
+        raise RuntimeError(message)
 
 _ensure_frontend()
 
@@ -55,6 +61,27 @@ def create_app() -> FastAPI:
     # --- Static Files and Root Redirect ---
     app.mount("/ui", StaticFiles(directory=str(FRONTEND_DIR), html=True), name="ui")
 
+    @app.middleware("http")
+    async def log_requests(request: Request, call_next):
+        logger.debug("Incoming request %s %s", request.method, request.url.path)
+        response = None
+        try:
+            response = await call_next(request)
+            logger.info(
+                "Handled request %s %s -> %s",
+                request.method,
+                request.url.path,
+                response.status_code,
+            )
+            return response
+        except Exception:
+            logger.exception(
+                "Unhandled error during request %s %s",
+                request.method,
+                request.url.path,
+            )
+            raise
+
     @app.get("/")
     async def root() -> RedirectResponse:
         return RedirectResponse(url="/ui/")
@@ -62,6 +89,7 @@ def create_app() -> FastAPI:
     # --- API Routes ---
     @app.get("/api/config")
     async def read_config() -> Dict[str, object]:
+        logger.debug("Configuration requested via API")
         config = get_config()
         return {
             "chat": _describe_endpoint(config.chat),
@@ -73,25 +101,36 @@ def create_app() -> FastAPI:
 
     @app.post("/api/config")
     async def update_config(payload: ConfigUpdatePayload) -> Dict[str, object]:
+        logger.info("Configuration update requested")
         try:
             media_config = build_media_config(payload)
             chat_config = payload.chat.to_model() if payload.chat else None
             configure(media=media_config, chat=chat_config)
         except Exception as exc:
+            logger.exception("Failed to update configuration")
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return await read_config()
 
     @app.get("/api/session/info")
     async def session_info() -> Dict[str, object]:
+        logger.debug("Session info requested")
         return state.vm.describe()
 
     @app.get("/api/session/boot")
     async def session_boot() -> Dict[str, object]:
+        logger.info("Session boot requested")
         return state.boot()
 
     @app.post("/api/chat")
     async def chat(request: ChatRequest) -> Dict[str, object]:
-        return state.respond(request.message)
+        try:
+            return state.respond(request.message)
+        except Exception as exc:
+            logger.exception("Chat processing failed")
+            raise HTTPException(
+                status_code=500,
+                detail="Internal server error. Please check server logs for details.",
+            ) from exc
 
     return app
 

--- a/src/okcvm/config.py
+++ b/src/okcvm/config.py
@@ -24,6 +24,10 @@ from typing import Mapping, Optional
 
 import yaml
 
+from .logging_utils import get_logger
+
+logger = get_logger(__name__)
+
 @dataclass(slots=True)
 class ModelEndpointConfig:
     """Configuration for a single model endpoint."""
@@ -144,7 +148,14 @@ def configure(
                 sound_effects=copy.deepcopy(media.sound_effects),
                 asr=copy.deepcopy(media.asr),
             )
-    print("✅ Configuration updated.")
+    logger.info("Configuration updated: chat=%s, media_services=%s",
+                bool(chat),
+                [service for service, cfg in (
+                    ("image", _config.media.image),
+                    ("speech", _config.media.speech),
+                    ("sound_effects", _config.media.sound_effects),
+                    ("asr", _config.media.asr),
+                ) if cfg])
 
 
 def get_config() -> Config:
@@ -168,15 +179,15 @@ def reset_config(env: Mapping[str, str] | None = None) -> None:
 def load_config_from_yaml(path: Path) -> None:
     """Loads configuration from a YAML file and applies it."""
     if not path.exists():
-        print(f"⚠️ Config file not found at {path}, skipping.")
+        logger.warning("Config file not found at %s, skipping load.", path)
         return
 
-    print(f"🚀 Loading configuration from {path}...")
+    logger.info("Loading configuration from %s", path)
     with open(path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
 
     if not data:
-        print("⚠️ Config file is empty, skipping.")
+        logger.warning("Config file at %s is empty, skipping.", path)
         return
         
     chat_config = data.get("chat")

--- a/src/okcvm/logging_utils.py
+++ b/src/okcvm/logging_utils.py
@@ -1,0 +1,154 @@
+"""Centralised logging utilities for the OKCVM project.
+
+This module provides a thin wrapper around the standard :mod:`logging`
+package so that the web server, background tools and CLI all emit messages
+using the same configuration.  The configuration is intentionally kept
+simple – console output for development visibility and a rotating log file
+for historical inspection – but can be customised through environment
+variables when required.
+
+Environment variables
+---------------------
+``OKCVM_LOG_LEVEL``
+    Overrides the default log level (``INFO``).  Any value understood by the
+    :mod:`logging` module is accepted (e.g. ``DEBUG``, ``WARNING``).
+
+``OKCVM_LOG_FILE``
+    Absolute or relative path to the log file.  Defaults to ``logs/okcvm.log``
+    inside the project root.  The directory is created automatically.
+
+The :func:`setup_logging` function is idempotent.  The first call sets up the
+handlers; subsequent calls are ignored to avoid interfering with loggers that
+may already be configured by Uvicorn or external libraries.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import logging
+import logging.config
+import os
+from typing import Any, Dict
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_LOG_DIR = PROJECT_ROOT / "logs"
+DEFAULT_LOG_FILE = DEFAULT_LOG_DIR / "okcvm.log"
+
+_LOGGING_INITIALISED = False
+
+
+def _normalise_log_file(path: str | os.PathLike[str] | None) -> Path:
+    """Return a validated path for the log file.
+
+    Parameters
+    ----------
+    path:
+        Optional path provided via configuration or environment variable.
+        Relative paths are resolved against the project root.
+    """
+
+    if path is None:
+        return DEFAULT_LOG_FILE
+
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        candidate = PROJECT_ROOT / candidate
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    return candidate
+
+
+def _build_logging_config(log_level: str, log_file: Path) -> Dict[str, Any]:
+    """Construct the ``dictConfig`` structure for logging."""
+
+    fmt = "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s"
+    uvicorn_fmt = (
+        "%(asctime)s | %(levelname)-8s | %(name)s | %(client_addr)s - "
+        "\"%(request_line)s\" %(status_code)s"
+    )
+
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "standard": {"format": fmt},
+            "uvicorn": {"format": uvicorn_fmt},
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "standard",
+                "level": log_level,
+            },
+            "file": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "formatter": "standard",
+                "filename": str(log_file),
+                "maxBytes": 5 * 1024 * 1024,
+                "backupCount": 5,
+                "encoding": "utf-8",
+                "level": log_level,
+            },
+            "uvicorn.access": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "formatter": "uvicorn",
+                "filename": str(log_file),
+                "maxBytes": 5 * 1024 * 1024,
+                "backupCount": 5,
+                "encoding": "utf-8",
+                "level": "INFO",
+            },
+        },
+        "loggers": {
+            "okcvm": {
+                "handlers": ["console", "file"],
+                "level": log_level,
+                "propagate": False,
+            },
+            "uvicorn": {
+                "handlers": ["console", "file"],
+                "level": log_level,
+            },
+            "uvicorn.error": {
+                "handlers": ["console", "file"],
+                "level": log_level,
+                "propagate": False,
+            },
+            "uvicorn.access": {
+                "handlers": ["uvicorn.access"],
+                "level": "INFO",
+                "propagate": False,
+            },
+        },
+        "root": {
+            "handlers": ["console", "file"],
+            "level": log_level,
+        },
+    }
+
+
+def setup_logging(*, log_level: str | None = None, log_file: str | os.PathLike[str] | None = None) -> None:
+    """Initialise logging for the process if it has not already been done."""
+
+    global _LOGGING_INITIALISED
+    if _LOGGING_INITIALISED:
+        return
+
+    level = (log_level or os.getenv("OKCVM_LOG_LEVEL") or "INFO").upper()
+    file_path = _normalise_log_file(log_file or os.getenv("OKCVM_LOG_FILE"))
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    config = _build_logging_config(level, file_path)
+    logging.config.dictConfig(config)
+    _LOGGING_INITIALISED = True
+
+
+def get_logger(name: str | None = None) -> logging.Logger:
+    """Return a configured logger, initialising logging if necessary."""
+
+    if not _LOGGING_INITIALISED:
+        setup_logging()
+    return logging.getLogger(name or "okcvm")
+
+
+__all__ = ["get_logger", "setup_logging", "PROJECT_ROOT", "DEFAULT_LOG_DIR", "DEFAULT_LOG_FILE"]
+


### PR DESCRIPTION
## Summary
- introduce a reusable logging utility with console and rotating file handlers, configurable through environment variables
- instrument the FastAPI application and session layer with detailed request, configuration, and error logging
- switch configuration helpers to use the shared logger and ignore generated log directories

## Testing
- pytest *(fails: missing optional dependency `psutil` required by deployment tests)*

------
https://chatgpt.com/codex/tasks/task_b_68df917c84ac8321b650ab5c018f533f