### PR TITLE
Add okcvm-server console script for easier startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,12 @@ OKCVM includes a full-featured web application that allows you to interact with 
 #### 1. Start the Service
 
 ```bash
-python -m okcvm.server
+# After `pip install -e .[dev]`
+okcvm-server
 ```
-The service will start on `http://localhost:8000`.
+This console script wraps the same Typer entry point as `python -m okcvm.server`,
+so you can launch the service directly from the project root without changing
+directories. The service will start on `http://localhost:8000`.
 
 #### 2. Open the UI
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -94,9 +94,12 @@ OKCVM 内置了一个功能齐全的 Web 应用，让你通过图形界面与智
 #### 1. 启动服务 (Start the Service)
 
 ```bash
-python -m okcvm.server
+# 在执行过 `pip install -e .[dev]` 之后
+okcvm-server
 ```
-服务将在 `http://localhost:8000` 启动。
+这个命令行入口与 `python -m okcvm.server` 使用同一个 Typer 应用，
+因此无需再切换目录，直接在项目根目录即可启动服务，默认地址为
+`http://localhost:8000`。
 
 #### 2. 打开用户界面 (Open the UI)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,8 @@ dev = [
   "pytest>=7.0",
 ]
 
+[project.scripts]
+okcvm-server = "okcvm.server:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary
- expose the Typer server entry point as an `okcvm-server` console script
- document the new shortcut in both the English and Chinese READMEs so the service can start without changing directories

## Testing
- Not run (server startup depends on optional LangChain-related dependencies that are slow to import in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68df930e0d308321b43e667495c32772