### PR TITLE
feat: anchor absolute tool paths inside workspace

### DIFF
--- a/src/okcvm/workspace.py
+++ b/src/okcvm/workspace.py
@@ -71,10 +71,12 @@ class WorkspaceManager:
         if posix_path.is_absolute():
             try:
                 relative = posix_path.relative_to(self._paths.mount)
-            except ValueError as exc:
-                raise WorkspaceError(
-                    f"Path '{raw_path}' is outside of the session workspace {self._paths.mount}"
-                ) from exc
+            except ValueError:
+                # The agent is using a generic absolute path (e.g. "/tmp/foo").
+                # Anchor it inside the session workspace so that the random
+                # workspace identifier does not need to be known a priori.
+                parts = posix_path.parts[1:]
+                relative = PurePosixPath(*parts)
         else:
             relative = posix_path
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,29 @@
+"""Tests for workspace path resolution helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from okcvm.workspace import WorkspaceManager
+
+
+def test_resolve_anchors_generic_absolute_path(tmp_path: Path) -> None:
+    """Absolute paths outside the mount are mapped inside the workspace."""
+
+    manager = WorkspaceManager(base_dir=tmp_path)
+
+    resolved = manager.resolve("/tmp/hello/world.txt")
+
+    expected = manager.paths.internal_root / "tmp" / "hello" / "world.txt"
+    assert resolved == expected
+
+
+def test_resolve_preserves_relative_path(tmp_path: Path) -> None:
+    """Relative paths remain relative to the workspace root."""
+
+    manager = WorkspaceManager(base_dir=tmp_path)
+
+    resolved = manager.resolve("project/readme.md")
+
+    expected = manager.paths.internal_root / "project" / "readme.md"
+    assert resolved == expected


### PR DESCRIPTION
## Summary
- teach `WorkspaceManager.resolve` to map generic absolute paths into the session-specific workspace automatically
- add regression coverage ensuring absolute and relative paths resolve within the workspace sandbox

## Testing
- pytest tests/test_workspace.py tests/test_tools_files.py

------
https://chatgpt.com/codex/tasks/task_b_68dfe2205ba08321b8abe956d4b2e313