### PR TITLE
Ensure workspace configuration is confirmed on server startup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -30,3 +30,9 @@ media:
   # asr:
   #   model: "whisper-1"
   #   api_key_env: "OPENAI_API_KEY"
+
+workspace:
+  # Path can be relative (resolved against this file) or absolute.
+  path: "workspace"
+  # Require a confirmation prompt before the server starts using the workspace.
+  confirm_on_start: true

--- a/src/okcvm/session.py
+++ b/src/okcvm/session.py
@@ -27,7 +27,9 @@ class SessionState:
         # self.history: List[Dict[str, str]] = []
 
     def _initialise_vm(self) -> None:
-        self.workspace = WorkspaceManager()
+        cfg = get_config()
+        workspace_root = cfg.workspace.resolve_and_prepare()
+        self.workspace = WorkspaceManager(base_dir=workspace_root)
         self.registry = ToolRegistry.from_default_spec(workspace=self.workspace)
         system_prompt = self.workspace.adapt_prompt(spec.load_system_prompt())
         self.vm = VirtualMachine(
@@ -46,6 +48,8 @@ class SessionState:
             "output": str(paths.output),
             "internal_root": str(paths.internal_root),
             "internal_output": str(paths.internal_output),
+            "internal_mount": str(getattr(paths, "internal_mount", paths.internal_root / "mnt")),
+            "internal_tmp": str(getattr(paths, "internal_tmp", paths.internal_root / "tmp")),
         }
 
         try:

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -6,8 +6,9 @@ pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 
 import okcvm.config as config_mod
-from okcvm.config import MediaConfig, ModelEndpointConfig
+from okcvm.config import MediaConfig, ModelEndpointConfig, WorkspaceConfig
 from okcvm.api import main
+from okcvm.session import SessionState
 
 
 @pytest.fixture(autouse=True)
@@ -21,11 +22,14 @@ def restore_config_state():
             config_mod._config = config_mod.AppConfig(  # type: ignore[attr-defined]
                 chat=copy.deepcopy(original.chat),
                 media=copy.deepcopy(original.media),
+                workspace=original.workspace.copy(),
             )
 
 
 @pytest.fixture
-def client():
+def client(tmp_path):
+    config_mod.configure(workspace=WorkspaceConfig(path=str(tmp_path)))
+    main.state = SessionState()
     return TestClient(main.create_app())
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ import pytest
 pytest.importorskip("yaml")
 
 import okcvm.config as config_mod
-from okcvm.config import MediaConfig, ModelEndpointConfig
+from okcvm.config import MediaConfig, ModelEndpointConfig, WorkspaceConfig
 
 
 @pytest.fixture(autouse=True)
@@ -19,6 +19,7 @@ def restore_config_state():
             config_mod._config = config_mod.AppConfig(  # type: ignore[attr-defined]
                 chat=copy.deepcopy(original.chat),
                 media=copy.deepcopy(original.media),
+                workspace=original.workspace.copy(),
             )
 
 
@@ -73,6 +74,15 @@ def test_configure_updates_media_without_affecting_chat():
     assert cfg.chat.model == "gpt-initial"
     assert cfg.media.image is not None
     assert cfg.media.image.model == "img-one"
+
+
+def test_configure_updates_workspace(tmp_path: Path):
+    workspace_cfg = WorkspaceConfig(path=str(tmp_path), confirm_on_start=False)
+    config_mod.configure(workspace=workspace_cfg)
+
+    cfg = config_mod.get_config()
+    assert cfg.workspace.confirm_on_start is False
+    assert cfg.workspace.resolve_path() == tmp_path.resolve()
 
 
 def test_load_config_from_yaml_supports_env_keys(tmp_path: Path, monkeypatch):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -10,6 +10,8 @@ def test_workspace_cleanup_removes_directory(tmp_path: Path) -> None:
     manager = WorkspaceManager(base_dir=tmp_path)
     internal_root = manager.paths.internal_root
     assert internal_root.exists()
+    assert manager.paths.internal_mount.exists()
+    assert manager.paths.internal_tmp.exists()
 
     removed = manager.cleanup()
     assert removed is True


### PR DESCRIPTION
## Summary
- add a WorkspaceConfig section that resolves workspace paths from config.yaml and ensures directories exist
- prompt for confirmation of the resolved workspace directory when starting the server and prepare the workspace root
- update session/workspace handling and tests to use the configured workspace base directory and new mnt/tmp folders

## Testing
- pytest tests/test_workspace.py tests/test_config.py tests/test_api_app.py


------
https://chatgpt.com/codex/tasks/task_b_68dfec8c1d1c83219f321aeb24057b6e