### PR TITLE
Address review feedback for snapshots and browser fallback

### DIFF
--- a/src/okcvm/api/main.py
+++ b/src/okcvm/api/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
 from ..config import ModelEndpointConfig, configure, get_config
@@ -192,18 +192,30 @@ def create_app() -> FastAPI:
         return state.list_workspace_snapshots(limit=limit)
 
     @app.post("/api/session/workspace/snapshots")
-    async def create_workspace_snapshot(payload: SnapshotCreatePayload) -> Dict[str, object]:
-        logger.info("Workspace snapshot creation requested label=%s", payload.label)
+    async def create_workspace_snapshot(
+        payload: SnapshotCreatePayload, limit: int = 20
+    ) -> Dict[str, object]:
+        logger.info(
+            "Workspace snapshot creation requested label=%s, limit=%s",
+            payload.label,
+            limit,
+        )
         try:
-            return state.snapshot_workspace(payload.label, limit=20)
+            return state.snapshot_workspace(payload.label, limit=limit)
         except WorkspaceStateError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @app.post("/api/session/workspace/restore")
-    async def restore_workspace_snapshot(payload: SnapshotRestorePayload) -> Dict[str, object]:
-        logger.info("Workspace restore requested snapshot=%s", payload.snapshot_id)
+    async def restore_workspace_snapshot(
+        payload: SnapshotRestorePayload, limit: int = 20
+    ) -> Dict[str, object]:
+        logger.info(
+            "Workspace restore requested snapshot=%s, limit=%s",
+            payload.snapshot_id,
+            limit,
+        )
         try:
-            return state.restore_workspace(payload.snapshot_id, limit=20)
+            return state.restore_workspace(payload.snapshot_id, limit=limit)
         except WorkspaceStateError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/src/okcvm/llm.py
+++ b/src/okcvm/llm.py
@@ -87,10 +87,17 @@ class _LenFriendlyToolProxy:
                 pass
         schema = getattr(self._tool, "args_schema", None)
         if schema is not None:
-            try:
-                return len(getattr(schema, "__fields__", schema))  # type: ignore[arg-type]
-            except TypeError:
-                pass
+            fields = getattr(schema, "__fields__", None)
+            if fields is None:
+                fields = getattr(schema, "model_fields", None)
+            if fields is not None:
+                try:
+                    return len(fields)  # type: ignore[arg-type]
+                except TypeError:
+                    pass
+        # LangChain expects ``len(tool)`` to be >= 2 when constructing default prompts.
+        # Falling back to 2 keeps compatibility with existing tests and agent logic
+        # while providing a deterministic value when the schema is unavailable.
         return 2
 
     def __repr__(self) -> str:

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -6,6 +6,7 @@ import requests
 import pytest
 
 from okcvm import ToolRegistry
+from okcvm.tools.deployment import ManifestJSONDecoder
 
 def kill_proc_tree(pid, sig=9, include_parent=True):
     """
@@ -74,7 +75,7 @@ def test_deploy_website_and_start_server(tmp_path, deployed_site_pid):
 
     # --- 4. 验证服务器相关的清单数据 ---
     with open(manifest_path, 'r') as f:
-        manifest_data = json.load(f)
+        manifest_data = json.load(f, cls=ManifestJSONDecoder)
 
     assert "server_info" in manifest_data
     server_info = manifest_data["server_info"]
@@ -129,7 +130,7 @@ def test_deploy_website_without_starting_server(tmp_path):
     assert "Serve the site with `python -m http.server" in result.output
 
     with open(Path(result.data["target"]) / "deployment.json", 'r') as f:
-        manifest_data = json.load(f)
+        manifest_data = json.load(f, cls=ManifestJSONDecoder)
 
     # 验证没有服务器信息
     assert manifest_data["server_info"] is None


### PR DESCRIPTION
## Summary
- remove the global JSON decoder monkey patch by introducing a dedicated manifest decoder helper
- make workspace snapshot create and restore endpoints accept a limit query parameter for consistent API responses
- simplify the browser navigation fallback logic and harden the len proxy for future Pydantic versions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dff336058c8321be319461fed8da11