### PR TITLE
Handle missing UI elements during chat initialization

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -908,9 +908,28 @@ async function sendChat(message) {
   }
 }
 
+function resolveUserInputField(form) {
+  if (userInput instanceof HTMLTextAreaElement || userInput instanceof HTMLInputElement) {
+    return userInput;
+  }
+  if (form instanceof HTMLFormElement) {
+    const fallback = form.querySelector('#user-input, textarea[name="message"]');
+    if (fallback instanceof HTMLTextAreaElement || fallback instanceof HTMLInputElement) {
+      return fallback;
+    }
+  }
+  const globalFallback = document.getElementById('user-input');
+  return globalFallback instanceof HTMLTextAreaElement || globalFallback instanceof HTMLInputElement
+    ? globalFallback
+    : null;
+}
+
 function handleUserSubmit(event) {
   event.preventDefault();
-  const value = userInput.value.trim();
+  const form = event.currentTarget instanceof HTMLFormElement ? event.currentTarget : chatForm;
+  const input = resolveUserInputField(form);
+  if (!input) return;
+  const value = typeof input.value === 'string' ? input.value.trim() : '';
   if (!value) return;
   addAndRenderMessage('user', value);
   sendChat(value);

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -26,10 +26,16 @@ function populateConfigForm(data) {
     const fields = serviceInputs[service];
     if (!fields) return;
     const entry = data?.[service];
-    fields.model.value = entry?.model ?? '';
-    fields.base_url.value = entry?.base_url ?? '';
-    fields.api_key.value = '';
-    fields.api_key.placeholder = entry?.api_key_present ? '已保存，更新请重新输入' : '••••••';
+    if (fields.model) {
+      fields.model.value = entry?.model ?? '';
+    }
+    if (fields.base_url) {
+      fields.base_url.value = entry?.base_url ?? '';
+    }
+    if (fields.api_key) {
+      fields.api_key.value = '';
+      fields.api_key.placeholder = entry?.api_key_present ? '已保存，更新请重新输入' : '••••••';
+    }
   });
 }
 
@@ -39,9 +45,9 @@ function collectConfigPayload() {
     const fields = serviceInputs[service];
     if (!fields) return;
     const entry = {};
-    const model = fields.model.value.trim();
-    const baseUrl = fields.base_url.value.trim();
-    const apiKey = fields.api_key.value.trim();
+    const model = fields.model?.value?.trim?.() ?? '';
+    const baseUrl = fields.base_url?.value?.trim?.() ?? '';
+    const apiKey = fields.api_key?.value?.trim?.() ?? '';
     if (model) entry.model = model;
     if (baseUrl) entry.base_url = baseUrl;
     if (apiKey) entry.api_key = apiKey;

--- a/frontend/previews.js
+++ b/frontend/previews.js
@@ -116,8 +116,12 @@ function handleOpenPreview() {
 }
 
 export function initializePreviewControls() {
-  togglePptModeButton.addEventListener('click', togglePptMode);
-  openWebPreviewButton.addEventListener('click', handleOpenPreview);
+  if (togglePptModeButton instanceof HTMLElement) {
+    togglePptModeButton.addEventListener('click', togglePptMode);
+  }
+  if (openWebPreviewButton instanceof HTMLElement) {
+    openWebPreviewButton.addEventListener('click', handleOpenPreview);
+  }
 }
 
 export function resetPreviews() {


### PR DESCRIPTION
## Summary
- guard the chat submit handler so it finds the textarea even when the cached element reference is unavailable
- make preview control and configuration form initialisation resilient to missing DOM nodes to avoid aborting startup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dffff3c7b883218531408e32381306