### PR TITLE
Avoid using cached user input element

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -909,9 +909,6 @@ async function sendChat(message) {
 }
 
 function resolveUserInputField(form) {
-  if (userInput instanceof HTMLTextAreaElement || userInput instanceof HTMLInputElement) {
-    return userInput;
-  }
   if (form instanceof HTMLFormElement) {
     const fallback = form.querySelector('#user-input, textarea[name="message"]');
     if (fallback instanceof HTMLTextAreaElement || fallback instanceof HTMLInputElement) {


### PR DESCRIPTION
## Summary
- update the user input resolution helper to query the DOM instead of returning a potentially stale cached element

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e00289c4448321a736254c5ad5ee0a