### PR TITLE
Fix StructuredTool proxy name handling

### DIFF
--- a/src/okcvm/llm.py
+++ b/src/okcvm/llm.py
@@ -71,6 +71,20 @@ class _LenFriendlyToolProxy:
         self._tool = tool
 
     def __getattr__(self, item: str) -> Any:
+        if item == "__name__":
+            if hasattr(self._tool, "__name__"):
+                return getattr(self._tool, "__name__")
+            if hasattr(self._tool, "name"):
+                return getattr(self._tool, "name")
+            return type(self._tool).__name__
+        if item == "__qualname__":
+            if hasattr(self._tool, "__qualname__"):
+                return getattr(self._tool, "__qualname__")
+            name = getattr(self, "__name__")
+            module = getattr(self._tool, "__module__", None)
+            if module:
+                return f"{module}.{name}"
+            return name
         return getattr(self._tool, item)
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
## Summary
- ensure the LangChain tool proxy exposes __name__ and __qualname__ so StructuredTool instances can be converted to OpenAI functions
- provide sensible fallbacks when wrapped tools are missing these attributes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e003261e34832182071ab5851c0083