### PR TITLE
docs: expand workspace and session tree guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,8 @@ together before diving into the source code.
 | [`architecture.md`](./architecture.md) | High-level system overview and data flow. |
 | [`backend.md`](./backend.md) | Detailed notes on the Python orchestrator, configuration, and CLI. |
 | [`frontend.md`](./frontend.md) | Summary of the bundled control panel and its behaviour. |
-| [`workspace.md`](./workspace.md) | Explanation of the session "virtual space" sandbox and file tooling. |
+| [`workspace.md`](./workspace.md) | Deep dive into the per-session sandbox, path resolution, and snapshotting. |
+| [`session_tree.md`](./session_tree.md) | Explains how conversation history, workspace snapshots, and tool artefacts form the session tree. |
 
 We keep these files short and link back to the canonical implementation files
 so that updates stay in sync with the codebase. When you add a new capability,

--- a/docs/session_tree.md
+++ b/docs/session_tree.md
@@ -1,0 +1,37 @@
+# 会话树（Session Tree）
+
+会话树是 OKCVM 中连接“对话历史、工作空间快照、部署成果和 PPT 产物”的核心索引结构。它把一次会话视为根节点，通过快照与工件生成的节点形成分支，支持回溯、复制以及跨工具的状态追踪。本章节从数据结构、Git 管理、回退策略以及部署/PPT 协调等角度详解会话树的工作方式。
+
+## 节点模型
+
+1. **根节点：会话实例** – `SessionState.boot()` 创建会话时会记录欢迎内容，并初始化 `VirtualMachine` 与 `WorkspaceManager`。根节点携带模型配置、会话 ID 以及初始预览信息，是所有后续节点的起点。【F:src/okcvm/session.py†L67-L150】
+2. **对话节点：历史消息** – `VirtualMachine.record_history_entry()` 会为每条消息生成带命名空间的递增 ID（如 `okcvm-12ab34cd-0001`），确保树形结构中每个节点都有稳定引用。`/api/session/history/{entry_id}` 接口可按 ID 取回任意节点的详细内容，前端据此绘制时间轴与分支。【F:src/okcvm/vm.py†L52-L108】【F:src/okcvm/vm.py†L118-L178】【F:src/okcvm/api/main.py†L148-L182】
+3. **工件节点：工具输出** – 当代理调用工具时，`VirtualMachine.call_tool()` 会把输入、输出和成功状态写入历史节点，使部署结果、PPT 文件等都成为会话树上的子节点，可被快照和回放。【F:src/okcvm/vm.py†L110-L157】
+
+## Git 快照与分支
+
+- `SessionState.respond()` 在生成回复后会触发 `GitWorkspaceState.snapshot()`，用用户消息摘要作为 commit 信息，返回的哈希被保存到响应的 `workspace_state` 字段中。前端会把这些哈希映射为会话树上的快照节点，允许用户在任意时间点创建分支或回滚。【F:src/okcvm/session.py†L94-L150】【F:src/okcvm/workspace.py†L120-L162】
+- `SessionState.restore_workspace()` 基于用户选择的 commit 哈希执行 `git reset --hard`，同时更新 `workspace_state`，从而把会话树指针回滚到对应节点。恢复后的快照 ID 会回写到响应中，确保 UI 与后端保持同步。【F:src/okcvm/session.py†L180-L207】【F:src/okcvm/workspace.py†L156-L167】
+
+## 会话与工作空间的互指
+
+- 每个会话节点都持有工作空间 ID，`VirtualMachine.describe()` 会把 `workspace_id`、`workspace_mount`、`workspace_output` 返回给 `/api/session/info`，供前端展示“当前指向的虚拟空间”。这保证了用户在树上切换节点时，始终能定位到对应的文件目录。【F:src/okcvm/vm.py†L158-L207】【F:src/okcvm/api/main.py†L148-L171】
+- 工具层通过注入的 `WorkspaceManager` 来解析路径，部署工具会把 `session_id` 写入 `deployment.json`，并把部署索引存放在工作空间根目录下。前端可以通过会话树节点读取这些元数据，判断某次部署来源于哪条对话分支。【F:src/okcvm/tools/deployment.py†L40-L170】
+
+## 回退与清理
+
+1. **单节点回退** – 调用 `/api/session/workspace/restore` 恢复到指定快照后，最新的 `workspace_state` 会记录 `latest_snapshot`，让前端将树指针指向目标节点，同时保持对话历史不变，方便用户继续在旧上下文上分支。【F:src/okcvm/api/main.py†L187-L222】
+2. **全量重置** – `/api/session/history` 的 DELETE 操作会清除 VM 历史并调用 `WorkspaceManager.cleanup()` 删除物理目录，相当于把会话树重置到根节点，只保留新的初始化分支。【F:src/okcvm/session.py†L152-L207】【F:src/okcvm/api/main.py†L172-L186】
+
+## 部署与 PPT 协作
+
+- **网站部署**：`DeployWebsiteTool` 会把生成的静态站点复制到会话工作空间的 `deployments/` 子目录，生成 `deployment.json` 记录部署 ID、预览地址和 `session_id`，并维护全局索引 `manifest.json`。会话树节点可引用这些文件来呈现部署状态或启动预览服务。【F:src/okcvm/tools/deployment.py†L70-L208】
+- **PPT 生成**：`SlidesGeneratorTool` 接受 HTML 片段，将带 `.ppt-slide` 类名的结构渲染为 PPTX，并写入工作空间（默认在 `generated_slides/` 目录）。该工具返回的文件路径会被 `SessionState.respond()` 收录在 `ppt_slides` 字段，使会话树的可视化层能直接展示最新 PPT 工件。【F:src/okcvm/tools/slides.py†L12-L78】【F:src/okcvm/session.py†L94-L150】
+
+## 管理最佳实践
+
+- 在会话树中创建新分支前，建议显式调用“创建快照”接口或依赖自动快照机制，确保后续可以精确回退。
+- 若需要对比不同分支生成的部署或 PPT，可通过 `workspace_id` 和快照哈希快速定位相应目录，再结合 `deployment.json` / PPTX 文件进行比对。
+- 批量清理旧节点时，先回收部署服务（停止 HTTP 服务器）并确认 PPT 文件是否需要归档，然后再执行历史删除，避免丢失重要工件。
+
+通过会话树，OKCVM 能够把对话、文件、部署与演示稿统一在同一套索引体系下，使复杂项目的协作与回溯更加可控。

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -1,46 +1,33 @@
-# Session workspace ("虚拟空间")
+# 工作空间（Workspace）
 
-Many OK Computer tools expect a sandboxed file system. OKCVM recreates that
-experience with a per-session "virtual space" managed by
-[`okcvm.workspace.WorkspaceManager`](../src/okcvm/workspace.py).
+OKCVM 为每个会话创建一个隔离的“虚拟空间”，确保工具调用和文件访问始终发生在独立的沙箱中。该机制由 `okcvm.workspace.WorkspaceManager` 驱动，并配合 Git 快照实现可回溯的状态管理。本章节详细描述工作空间的目录结构、生命周期、路径解析策略以及和会话、API 的集成方式。
 
-## How the workspace is created
-- The manager generates a random mount path like `/mnt/okcvm-12ab34cd/` and maps
-  it to a private directory under the system temp folder. Both the public mount
-  and the internal output directory are tracked in a `WorkspacePaths` dataclass.
-  【F:src/okcvm/workspace.py†L11-L49】
-- `SessionState` injects the workspace into the default tool registry so every
-  tool that declares `requires_workspace` is automatically scoped to the session.
-  【F:src/okcvm/session.py†L29-L36】
+## 目录结构与初始化
 
-## Path resolution rules
-- `WorkspaceManager.resolve` accepts user-provided paths, normalises them, and
-  anchors them inside the internal root. Absolute paths outside the mount are
-  re-based under the session to prevent leakage, and attempts to escape the root
-  raise `WorkspaceError`. 【F:src/okcvm/workspace.py†L51-L97】
-- Regression tests confirm both absolute (`/tmp/...`) and relative
-  (`project/readme.md`) paths resolve to the session directory. 【F:tests/test_workspace.py†L1-L24】
+1. **会话挂载点**：启动时生成随机挂载名（如 `/mnt/okcvm-12ab34cd/`），并在系统临时目录下创建对应的内部根目录。内部目录包含 `mnt/`、`output/`、`tmp/` 子目录，用于分别映射公开挂载、工具输出与临时文件。【F:src/okcvm/workspace.py†L32-L89】
+2. **路径快照**：所有路径被封装在 `WorkspacePaths` 数据类中，包含会话 ID、公开路径（`mount`、`output`）以及内部真实路径，方便在日志和 API 中统一引用。【F:src/okcvm/workspace.py†L168-L211】
+3. **清理机制**：`WorkspaceManager.cleanup()` 会在会话结束或手动重置时递归删除内部根目录，避免跨会话污染。重复调用会被安全地忽略以保证幂等性。【F:src/okcvm/workspace.py†L228-L263】
 
-## Prompt adaptation
-- The manager rewrites legacy instructions in the upstream system prompt so that
-  agents receive the correct mount/output paths for the current session. This is
-  why the UI and CLI display randomised workspace IDs in session metadata.
-  【F:src/okcvm/workspace.py†L99-L108】【F:src/okcvm/vm.py†L163-L176】
+## 路径解析与沙箱策略
 
-## Git-backed state management
-- Workspaces now bootstrap a lightweight Git repository through
-  `GitWorkspaceState`, enabling snapshot/restore without leaking outside the
-  sandbox. The manager falls back gracefully when Git is unavailable.
-  【F:src/okcvm/workspace.py†L15-L167】
-- `SessionState` publishes snapshot metadata with every response and exposes
-  helpers for manual snapshots or rollbacks, making "虚拟空间" time travelable in
-  multi-turn sessions. 【F:src/okcvm/session.py†L25-L164】
-- FastAPI endpoints surface the snapshot list, creation, and restore actions for
-  the frontend; end-to-end tests cover both the backend API and Git round trip.
-  【F:src/okcvm/api/main.py†L17-L205】【F:tests/test_api_app.py†L1-L142】【F:tests/test_workspace.py†L1-L62】
+- 所有用户输入的路径都会交给 `WorkspaceManager.resolve()` 处理。该方法会统一分隔符、支持相对路径，并且将所有绝对路径重新定位到当前会话的内部根目录下。如果解析结果试图逃逸根目录，会抛出 `WorkspaceError` 终止操作。【F:src/okcvm/workspace.py†L212-L227】【F:src/okcvm/workspace.py†L242-L264】
+- 为了兼容旧版系统提示词，`WorkspaceManager.adapt_prompt()` 会将提示词中的历史挂载路径（`/mnt/okcomputer/`、`/mnt/okcomputer/output/`）替换为当前会话的随机挂载路径，使得代理始终感知正确的沙箱位置。【F:src/okcvm/workspace.py†L266-L281】
 
-## User-facing documentation
-- Both READMEs explain the virtual workspace contract, highlighting that file
-  tools stay within the sandbox and that crossing the boundary yields an error.
-  Share this section with contributors who are confused about "虚拟空间" paths.
-  【F:README.md†L156-L156】【F:README_ZH.md†L148-L148】
+## Git 驱动的快照
+
+- `GitWorkspaceState` 会在工作空间根目录下初始化 Git 仓库，并设置隔离的环境变量，确保提交不会污染系统级 Git 配置。若运行环境缺少 Git，可回退到 `_NullWorkspaceState`，此时快照功能被禁用但工作空间依旧可用。【F:src/okcvm/workspace.py†L44-L118】
+- 每次创建快照会执行 `git add -A`、`git commit` 并返回最新的 commit 哈希，以便前端通过会话树引用具体节点。快照条目记录 ID、标签和时间戳，可通过 API 查询最近 N 条历史。【F:src/okcvm/workspace.py†L120-L162】
+- 恢复动作会 `git reset --hard` 指定哈希并清理未跟踪文件，实现可预测的回滚能力；若传入未知哈希，系统会抛出 `WorkspaceStateError` 并阻止恢复。【F:src/okcvm/workspace.py†L156-L167】
+
+## 会话生命周期中的挂载
+
+1. **创建会话**：`SessionState._initialise_vm()` 调用配置层获得持久根目录，实例化 `WorkspaceManager`，并将其注入默认工具注册表，保证所有声明 `requires_workspace` 的工具自动获得沙箱上下文。【F:src/okcvm/session.py†L22-L44】
+2. **响应消息**：在 `SessionState.respond()` 中，每次回复都会根据用户输入生成快照标签，调用 `workspace.state.snapshot()` 捕捉当前文件状态，并把快照摘要嵌入返回 payload 的 `workspace_state` 字段，供前端渲染会话树节点。【F:src/okcvm/session.py†L94-L150】
+3. **重置与清理**：`SessionState.delete_history()` 和 `SessionState.reset()` 会先调用工作空间清理，再重新初始化 VM 与工作空间，确保旧文件不会影响新会话。【F:src/okcvm/session.py†L152-L207】
+
+## API 与工具集成
+
+- FastAPI 提供列出、创建、恢复快照的 REST 接口，分别映射到 `GET /api/session/workspace/snapshots`、`POST /api/session/workspace/snapshots` 与 `POST /api/session/workspace/restore`。错误会统一包装为 `WorkspaceStateError` 并以 400 返回。【F:src/okcvm/api/main.py†L187-L222】
+- 所有需要文件系统的工具（如网站部署、PPT 生成等）都通过注入的 `WorkspaceManager` 解析路径，保证它们的输入输出落在当前会话目录内，并能被后续快照捕获，实现跨工具的一致状态管理。【F:src/okcvm/tools/deployment.py†L70-L116】【F:src/okcvm/tools/slides.py†L32-L73】
+
+通过以上机制，工作空间章节保证了在多会话、多工具场景下的数据隔离、安全访问和时间旅行能力，是会话树运作的基础。


### PR DESCRIPTION
## Summary
- rewrite the workspace documentation with detailed lifecycle, path resolution, and Git snapshot explanations
- add a dedicated session tree guide covering history nodes, workspace rollbacks, and deployment/PPT artefact management
- update the docs index to reference the new session tree chapter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e00d1438bc8321a80477403ecd628e