### PR TITLE
feat: render chat markdown responses

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,4 +1,5 @@
 import { cloneMessageActionIcon } from './messageActionIcons.js';
+import { renderMarkdown } from './markdown.js';
 import {
   chatMessages,
   chatForm,
@@ -160,7 +161,7 @@ function markMessagePending(messageElement, placeholderText) {
   if (!(messageElement instanceof HTMLElement)) return;
   messageElement.dataset.pending = 'true';
   messageElement.classList.add('pending');
-  const body = messageElement.querySelector('p');
+  const body = messageElement.querySelector('.message-content');
   if (body) {
     body.classList.add('pending');
     body.textContent = placeholderText ?? '正在生成回复…';
@@ -347,8 +348,10 @@ function createMessageElement(role, text, options = {}) {
   });
   header.append(name, time);
 
-  const body = document.createElement('p');
-  body.textContent = typeof text === 'string' && text.length > 0 ? text : '';
+  const body = document.createElement('div');
+  body.className = 'message-content';
+  const initialText = typeof text === 'string' ? text : '';
+  body.innerHTML = renderMarkdown(initialText);
 
   const actions = document.createElement('div');
   actions.className = 'message-actions';
@@ -442,9 +445,9 @@ function finalizePendingMessage(message, text, messageId) {
     return;
   }
 
-  const body = message.querySelector('p');
+  const body = message.querySelector('.message-content');
   if (body) {
-    body.textContent = finalText;
+    body.innerHTML = renderMarkdown(finalText);
     body.classList.remove('pending');
   }
 
@@ -479,7 +482,7 @@ async function handleCopyMessageAction(messageId, button, messageElement) {
   }
 
   if (!content && messageElement instanceof HTMLElement) {
-    const body = messageElement.querySelector('p');
+    const body = messageElement.querySelector('.message-content');
     if (body) {
       content = body.innerText ?? body.textContent ?? '';
     }
@@ -510,7 +513,7 @@ function handleEditMessageAction(messageElement, messageId) {
   const previousMessages = conversation.messages.map((entry) => ({ ...entry }));
   const previousSelections = captureBranchSelections(conversation.branches);
 
-  const body = messageElement.querySelector('p');
+  const body = messageElement.querySelector('.message-content');
   const currentContent = typeof message.content === 'string' ? message.content : body?.textContent ?? '';
   const nextContent = window.prompt('编辑这条消息', currentContent ?? '');
   if (nextContent === null) return;
@@ -523,7 +526,7 @@ function handleEditMessageAction(messageElement, messageId) {
   bumpConversation(conversation.id);
 
   if (body) {
-    body.textContent = normalized;
+    body.innerHTML = renderMarkdown(normalized);
   }
 
   const timeElement = messageElement.querySelector('time');

--- a/frontend/markdown.js
+++ b/frontend/markdown.js
@@ -1,0 +1,28 @@
+import { marked } from 'https://cdn.jsdelivr.net/npm/marked@11.2.0/lib/marked.esm.js';
+import createDOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.0.8/dist/purify.es.mjs';
+
+const DOMPurify = createDOMPurify(window);
+
+marked.setOptions({
+  gfm: true,
+  breaks: true,
+  mangle: false,
+  headerIds: false,
+});
+
+/**
+ * 将 Markdown 文本渲染为经过净化的 HTML 字符串。
+ * @param {string} markdown - 待渲染的 Markdown 文本
+ * @param {{ inline?: boolean }} [options]
+ * @returns {string}
+ */
+export function renderMarkdown(markdown, options = {}) {
+  const { inline = false } = options;
+  const source = typeof markdown === 'string' ? markdown : '';
+  if (!source.trim()) {
+    return '';
+  }
+
+  const html = inline ? marked.parseInline(source) : marked.parse(source);
+  return DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
+}

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -391,7 +391,78 @@ body.no-scroll { overflow: hidden; }
 .message.user { margin-left: auto; background: var(--chat-user-bg); border-top-right-radius: 0.5rem; border: 1px solid rgba(59, 130, 246, 0.2); }
 .message.assistant { background: var(--chat-assistant-bg); border-top-left-radius: 0.5rem; border: 1px solid rgba(139, 92, 246, 0.2); }
 .message header { display: flex; align-items: center; gap: 0.6rem; font-size: 0.85rem; color: var(--text-secondary); font-weight: 500; }
-.message p { margin: 0; line-height: 1.6; white-space: pre-wrap; color: var(--text-primary); }
+.message .message-content {
+  line-height: 1.6;
+  color: var(--text-primary);
+  white-space: normal;
+  word-break: break-word;
+}
+
+.message .message-content p,
+.message .message-content ul,
+.message .message-content ol,
+.message .message-content pre {
+  margin: 0 0 0.75rem 0;
+}
+
+.message .message-content ul,
+.message .message-content ol {
+  padding-left: 1.25rem;
+}
+
+.message .message-content li + li {
+  margin-top: 0.35rem;
+}
+
+.message .message-content blockquote {
+  margin: 0 0 0.75rem 0;
+  padding-left: 1rem;
+  border-left: 3px solid rgba(148, 163, 184, 0.3);
+  color: var(--text-secondary);
+}
+
+.message .message-content a {
+  color: #A5B4FC;
+  text-decoration: underline;
+  text-decoration-color: rgba(165, 180, 252, 0.35);
+}
+
+.message .message-content a:hover,
+.message .message-content a:focus {
+  text-decoration-color: rgba(165, 180, 252, 0.75);
+}
+
+.message .message-content code {
+  font-family: 'Fira Code', 'JetBrains Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.9em;
+  background: rgba(148, 163, 184, 0.16);
+  color: #E0E7FF;
+  padding: 0.15rem 0.35rem;
+  border-radius: 0.4rem;
+}
+
+.message .message-content pre {
+  padding: 0.85rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
+  overflow-x: auto;
+}
+
+.message .message-content pre code {
+  display: block;
+  background: transparent;
+  padding: 0;
+  color: inherit;
+}
+
+.message .message-content > :last-child {
+  margin-bottom: 0;
+}
+
+.message .message-content.pending {
+  color: var(--text-secondary);
+}
 .message-footer { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; margin-top: 0.2rem; flex-wrap: wrap; }
 .message.assistant .message-footer { justify-content: flex-end; }
 .message-actions { display: flex; flex-wrap: wrap; gap: 0.35rem; font-size: 0.78rem; color: var(--text-secondary); }
@@ -421,8 +492,12 @@ body.no-scroll { overflow: hidden; }
 .message-action[data-loading='true'] .icon { animation: spin 1s linear infinite; }
 .message.pending .message-actions { opacity: 0.6; }
 .message.pending { opacity: 0.9; }
-.message.assistant[data-pending='true'] p { color: var(--text-secondary); display: inline-flex; align-items: center; }
-.message.assistant[data-pending='true'] p::after {
+.message.assistant[data-pending='true'] .message-content.pending {
+  display: inline-flex;
+  align-items: center;
+}
+
+.message.assistant[data-pending='true'] .message-content.pending::after {
   content: '';
   width: 1rem;
   height: 1rem;


### PR DESCRIPTION
## Summary
- add a dedicated markdown renderer that wraps marked with DOMPurify so chat messages are sanitized html
- render conversation messages with the markdown renderer and keep copy/edit flows in sync with the html output
- style rendered markdown elements like lists, code blocks, links, and pending states for the updated layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e01334d0dc83218cc43bfd3b210dc6