### PR TITLE
Serve deployments from numeric root paths

### DIFF
--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -138,6 +138,7 @@ def test_deploy_website_without_starting_server(tmp_path):
     # 验证没有服务器信息
     assert manifest_data["server_info"] is None
     assert manifest_data.get("server_preview_url") is None
+    assert manifest_data["preview_url"].endswith("&path=index.html")
     # 验证 PID 不存在（以防万一）
     assert not psutil.pid_exists(manifest_data.get("server_info", {}).get("pid", -1))
 


### PR DESCRIPTION
## Summary
- serve deployment assets directly from `/{deployment_id}` and nested paths without affecting existing query-based preview access
- keep deployment manifests pointing at the `?s={id}&path=` preview URLs to preserve documented behaviour
- cover direct-path access in API tests and update deployment tests for the restored preview URL format

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68e012c7011c83219c39ab66445b4eca