### PR TITLE
Normalize web preview payloads and open links safely

### DIFF
--- a/frontend/markdown.js
+++ b/frontend/markdown.js
@@ -3,6 +3,13 @@ import createDOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.0.8/dist/p
 
 const DOMPurify = createDOMPurify(window);
 
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.hasAttribute('href')) {
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
 marked.setOptions({
   gfm: true,
   breaks: true,


### PR DESCRIPTION
## Summary
- parse structured tool outputs on the server so chat responses expose web preview HTML or URLs
- normalise preview payloads in the UI to render either inline HTML or remote deployments and keep the open button in sync
- ensure rendered markdown links open in a new tab with noopener safeguards

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e017ffd174832187b4720986dbb525