### PR TITLE
docs: clarify single-session limitation for demo server

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,13 @@ On your first visit, the UI will guide you through the setup process.
 
 Once configured, you're ready to interact with the agent in the chat interface! All messages are sent to the backend VM for processing and will return curated previews and results.
 
-#### 5. Troubleshooting Tool Errors
+#### 5. Concurrency & Multi-User Access
+
+The demo FastAPI service keeps a single global `SessionState` instance in [`src/okcvm/api/main.py`](src/okcvm/api/main.py), so every browser tab shares the same conversation and workspace context. There is no automatic per-visitor isolation in this mode.【F:src/okcvm/api/main.py†L63-L69】
+
+To run multi-user or multi-session deployments, allocate a dedicated `SessionState` per user (for example by binding it to an authenticated account or an explicit session ID) and pass that instance into the relevant API routes.
+
+#### 6. Troubleshooting Tool Errors
 
 - **Session workspace paths**: Every chat session is assigned a random virtual mount such as `/mnt/okcvm-12ab34cd/`. The file tools (`mshtools-write_file`, `mshtools-read_file`, `mshtools-edit_file`) automatically resolve relative paths inside this mount, so commands like `resume-website/index.html` are stored safely without leaking across sessions. Passing a path outside the mount will raise a "path outside workspace" error.
 - **State snapshots**: Each workspace is Git-backed. OKCVM automatically checkpoints the sandbox after every assistant reply and exposes API endpoints so you can list snapshots or roll back to a previous turn—perfect for "oops" moments in long multi-turn projects.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -143,7 +143,13 @@ okcvm-server
 
 配置完成后，你就可以在聊天界面中与智能体进行交互了！所有消息都会被发送到后端的虚拟机进行处理，并返回精心编排的预览和结果。
 
-#### 5. 常见工具错误排查 (Troubleshooting Tool Errors)
+#### 5. 并发与多用户访问 (Concurrency & Multi-User Access)
+
+当前的 FastAPI 服务在 `src/okcvm/api/main.py` 中维护了一个全局的 `SessionState` 单例，用于演示目的。也就是说，所有浏览器客户端都会共享同一个对话会话和工作空间，并不会为每位访客自动创建隔离上下文。【F:src/okcvm/api/main.py†L63-L69】
+
+如果需要支持真正的多用户或多会话并发，你需要在应用层为每位用户分配独立的 `SessionState` 实例（例如基于登录态或显式的会话 ID），并将它们注入到对应的 API 路由中。
+
+#### 6. 常见工具错误排查 (Troubleshooting Tool Errors)
 
 - **会话工作区路径 (Session workspace paths)**：每次会话都会自动分配一个随机的虚拟挂载路径，例如 `/mnt/okcvm-12ab34cd/`。`mshtools-write_file`、`mshtools-read_file` 和 `mshtools-edit_file` 会自动将相对路径映射到该工作区，因此可以直接写入 `resume-website/index.html` 等相对路径；如果传入的路径不在当前会话的挂载目录下，工具会提示路径越界错误。当前会话的真实文件将被保存在后端临时目录中，互不干扰。
 - **状态快照 (State snapshots)**：工作区默认由 Git 管理。系统会在每次助手回复后自动创建快照，并提供 API 让你查看快照列表或一键回滚到之前的版本，长链路协作时出错也能快速恢复。


### PR DESCRIPTION
## Summary
- explain in the English and Chinese READMEs that the FastAPI demo uses a single global SessionState
- note the need to allocate per-user SessionState instances to enable true multi-user deployments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e082711e0483219eb5041f399d3f44