### PR TITLE
Preserve workspace during session boot

### DIFF
--- a/docs/session_tree.md
+++ b/docs/session_tree.md
@@ -4,7 +4,7 @@
 
 ## 节点模型
 
-1. **根节点：会话实例** – `SessionState.boot()` 创建会话时会记录欢迎内容，并初始化 `VirtualMachine` 与 `WorkspaceManager`。根节点携带模型配置、会话 ID 以及初始预览信息，是所有后续节点的起点。【F:src/okcvm/session.py†L67-L150】
+1. **根节点：会话实例** – `SessionState.boot()` 在第一次请求时记录欢迎内容，并返回当前 `VirtualMachine` / `WorkspaceManager` 的描述信息。若需要重新初始化工作台，应通过 `SessionState.delete_history()` 或 `SessionState.reset()` 触发清理，再由下一次 `boot` 请求生成新的根节点元数据。【F:src/okcvm/session.py†L18-L220】
 2. **对话节点：历史消息** – `VirtualMachine.record_history_entry()` 会为每条消息生成带命名空间的递增 ID（如 `okcvm-12ab34cd-0001`），确保树形结构中每个节点都有稳定引用。`/api/session/history/{entry_id}` 接口可按 ID 取回任意节点的详细内容，前端据此绘制时间轴与分支。【F:src/okcvm/vm.py†L52-L108】【F:src/okcvm/vm.py†L118-L178】【F:src/okcvm/api/main.py†L148-L182】
 3. **工件节点：工具输出** – 当代理调用工具时，`VirtualMachine.call_tool()` 会把输入、输出和成功状态写入历史节点，使部署结果、PPT 文件等都成为会话树上的子节点，可被快照和回放。【F:src/okcvm/vm.py†L110-L157】
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -819,7 +819,18 @@ function selectConversation(conversationId) {
   }
 }
 
-function startNewConversation() {
+async function startNewConversation() {
+  setStatus('清理工作台…', true);
+
+  try {
+    await deleteSessionHistory();
+  } catch (error) {
+    console.error(error);
+    setStatus('待命中…');
+    addAndRenderMessage('assistant', `无法重置会话：${error?.message || '未知错误'}`);
+    return;
+  }
+
   const conversation = createConversation();
   renderConversationList();
   renderConversation(conversation);

--- a/src/okcvm/session.py
+++ b/src/okcvm/session.py
@@ -22,6 +22,7 @@ class SessionState:
 
     def __init__(self) -> None:
         logger.debug("Initialising SessionState and tool registry")
+        self._booted = False
         self._initialise_vm()
         self._rng = random.Random()
         # 注意：VM现在管理自己的历史，SessionState的历史可以作为副本或移除
@@ -38,6 +39,7 @@ class SessionState:
             system_prompt=system_prompt,
             registry=self.registry,
         )
+        self._booted = False
 
     def _workspace_state_summary(self, *, latest: Optional[str] = None, limit: int = 10) -> Dict[str, object]:
         state = getattr(self.workspace, "state", None)
@@ -207,15 +209,20 @@ class SessionState:
         }
 
     def boot(self) -> Dict[str, object]:
-        """
-        Boots the session, but now it doesn't need to return hardcoded content.
-        It simply initializes the state.
-        """
-        self.reset()
+        """Return the welcome payload without resetting existing workspace state."""
 
-        # 引导信息仍然可以是静态的
-        boot_reply = constants.WELCOME_MESSAGE
-        self.vm.record_history_entry({"role": "assistant", "content": boot_reply})
+        logger.info("Session boot requested (booted=%s)", self._booted)
+
+        if not self._booted:
+            boot_reply = constants.WELCOME_MESSAGE
+            self.vm.record_history_entry({"role": "assistant", "content": boot_reply})
+            self._booted = True
+        else:
+            history = self.vm.history
+            if history and history[0].get("role") == "assistant":
+                boot_reply = str(history[0].get("content", constants.WELCOME_MESSAGE))
+            else:
+                boot_reply = constants.WELCOME_MESSAGE
 
         logger.info("Session booted (history=%s)", len(self.vm.history))
 

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -179,6 +179,22 @@ def test_session_endpoints_use_session_state(monkeypatch, client):
     assert "system_prompt" in info.json()
 
 
+def test_boot_does_not_reset_existing_workspace(client):
+    first_boot = client.get("/api/session/boot")
+    assert first_boot.status_code == 200
+
+    workspace = main.state.workspace
+    workspace_root = workspace.paths.internal_root
+    sentinel = workspace.paths.internal_output / "sentinel.txt"
+    sentinel.write_text("preserve", encoding="utf-8")
+
+    second_boot = client.get("/api/session/boot")
+    assert second_boot.status_code == 200
+
+    assert sentinel.exists()
+    assert main.state.workspace.paths.internal_root == workspace_root
+
+
 def test_delete_session_history_removes_workspace(client):
     boot = client.get("/api/session/boot")
     assert boot.status_code == 200


### PR DESCRIPTION
## Summary
- stop SessionState.boot from resetting the workspace so reopening the UI keeps prior artifacts
- make the new-conversation flow explicitly clear server state before booting and surface failures to the user
- document the new lifecycle and add a regression test ensuring boot calls leave the workspace intact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e08329160c83218824ef9074d78d09