### PR TITLE
Pass replace_last flag through chat endpoint

### DIFF
--- a/src/okcvm/api/main.py
+++ b/src/okcvm/api/main.py
@@ -342,11 +342,12 @@ def create_app() -> FastAPI:
     ) -> Dict[str, object]:
         session = _get_session(request, client_id)
         logger.info(
-            "Chat request received client=%s: %s",
+            "Chat request received client=%s replace_last=%s: %s",
             session.client_id,
+            payload.replace_last,
             payload.message[:120],
         )
-        response = session.respond(payload.message)
+        response = session.respond(payload.message, replace_last=payload.replace_last)
         logger.debug(
             "Chat response generated (preview=%s, history=%s, summary=%s)",
             bool(response.get("web_preview")),


### PR DESCRIPTION
## Summary
- include the replace_last flag in chat request logging
- pass the replace_last option through to Session.respond so regenerations work via the API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e0890ca65c8321b408d3fa52ac6a1f