### PR TITLE
Refresh roadmap and expand developer docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,19 +1,39 @@
 # Developer Documentation
 
-Welcome to the OKCVM knowledge base. This directory collects concise notes
-about the major subsystems so newcomers can understand how the pieces fit
-together before diving into the source code.
+Welcome to the OK Computer Virtual Machine (OKCVM) knowledge base. This folder
+describes how the orchestrator, API, workspace sandbox, and operator console work
+together. If you are onboarding, start here before diving into the source tree.
 
 ## Document map
 
 | File | Purpose |
 | ---- | ------- |
-| [`architecture.md`](./architecture.md) | High-level system overview and data flow. |
-| [`backend.md`](./backend.md) | Detailed notes on the Python orchestrator, configuration, and CLI. |
-| [`frontend.md`](./frontend.md) | Summary of the bundled control panel and its behaviour. |
-| [`workspace.md`](./workspace.md) | Deep dive into the per-session sandbox, path resolution, and snapshotting. |
-| [`session_tree.md`](./session_tree.md) | Explains how conversation history, workspace snapshots, and tool artefacts form the session tree. |
+| [`architecture.md`](./architecture.md) | System decomposition, runtime flow, and integration points between backend, frontend, and tooling. |
+| [`backend.md`](./backend.md) | Detailed explanation of configuration, LangChain orchestration, FastAPI routes, and supporting utilities. |
+| [`frontend.md`](./frontend.md) | Walkthrough of the static control panel, state management, accessibility patterns, and preview rendering. |
+| [`workspace.md`](./workspace.md) | Deep dive into per-session sandboxes, Git snapshots, path resolution, and tool injection. |
+| [`session_tree.md`](./session_tree.md) | Conceptual model for how chat history, workspace commits, deployments, and artefacts form a navigable tree. |
 
-We keep these files short and link back to the canonical implementation files
-so that updates stay in sync with the codebase. When you add a new capability,
-please update or extend the relevant document.
+## How to use this folder
+
+- **Keep docs and code in sync.** Whenever you modify core runtime logic, update
+the corresponding section. The tables above should always reflect the actual
+responsibilities of each module.【F:docs/backend.md†L1-L124】
+- **Link to source.** Inline citations (e.g. `【F:src/...】`) reference canonical
+implementations so future contributors can audit behaviour quickly.
+- **Prefer English.** All technical documentation is maintained in English to
+serve the global engineering team. Localised product copy belongs in the
+frontend assets or runtime constants.【F:src/okcvm/constants.py†L1-L120】
+
+## Editing checklist
+
+1. Verify the README and roadmap capture the newly delivered capability.
+2. Update architecture/backend docs when introducing new services, background
+   jobs, or configuration structures.
+3. Extend the workspace and session tree guides whenever tools rely on new
+   directory layouts or metadata conventions.
+4. Run `pytest` after major changes and record additional learnings in the
+docs if a regression revealed missing context.【F:tests/test_api_app.py†L1-L145】
+
+Treat this directory as part of the codebase—pull requests without matching
+documentation updates should be rare exceptions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,41 +1,67 @@
 # Architecture Overview
 
-This project re-packages Moonshot's OK Computer agent into a self-hostable
-stack. The repository is organised into four primary layers:
+OKCVM repackages Moonshot's OK Computer agent into a self-hostable platform. The
+system is composed of modular layers that keep the canonical specification,
+Python orchestrator, FastAPI API, and static operator console loosely coupled.
+
+## Subsystem map
 
 1. **Specification bundle** – The upstream system prompt and tool manifest live
    in [`spec/system_prompt.md`](../spec/system_prompt.md) and
-   [`spec/tools.json`](../spec/tools.json). `okcvm.spec` exposes helpers for
-   reading these assets and returning structured dataclasses that other modules
-   can consume. 【F:src/okcvm/spec.py†L1-L168】
-2. **Python orchestrator** – Core runtime modules under `src/okcvm/` implement
-   configuration, tool registration, LangChain integration, and session
-   lifecycle management. These pieces power both the CLI (`main.py`) and the
-   FastAPI surface. 【F:src/okcvm/config.py†L25-L227】【F:src/okcvm/registry.py†L1-L200】【F:src/okcvm/vm.py†L20-L178】
-3. **HTTP API** – [`src/okcvm/api/main.py`](../src/okcvm/api/main.py) instantiates
-   a FastAPI application, wires middleware, serves the static frontend, and
-   exposes the `/api/*` endpoints used by the UI. 【F:src/okcvm/api/main.py†L1-L145】
+   [`spec/tools.json`](../spec/tools.json). `okcvm.spec` exposes dataclasses and
+   helpers that parse these assets, providing typed accessors for downstream
+   modules.【F:src/okcvm/spec.py†L1-L168】
+2. **Runtime core** – Modules under [`src/okcvm/`](../src/okcvm) handle
+   configuration, logging, registry wiring, LangChain integration, workspace
+   management, and session lifecycle. They are pure Python and power both the CLI
+   and API surfaces.【F:src/okcvm/config.py†L25-L227】【F:src/okcvm/vm.py†L26-L178】
+3. **HTTP API** – [`okcvm.api.main`](../src/okcvm/api/main.py) wraps FastAPI,
+   serves static assets, implements authentication-free REST endpoints, and keeps
+   multi-client session state in-memory via `SessionStore`.【F:src/okcvm/api/main.py†L58-L309】
 4. **Control panel frontend** – Static assets in [`frontend/`](../frontend)
-   provide a lightweight dashboard for configuring endpoints, running chats, and
-   reviewing execution traces. 【F:frontend/index.html†L1-L210】【F:frontend/app.js†L1-L360】
+   deliver the dashboard experience with persistent conversations, settings
+   management, preview panes, and telemetry timelines.【F:frontend/index.html†L16-L220】【F:frontend/app.js†L1-L851】
 
-## Runtime flow
+## Request lifecycle
 
-1. When the CLI (`main.py`) launches the server, it ensures dependencies are
-   available, loads layered configuration (`config.yaml` + environment), and
-   starts Uvicorn against the FastAPI app. 【F:main.py†L1-L120】
-2. `SessionState` bootstraps a `WorkspaceManager`, loads the canonical system
-   prompt, and constructs a `VirtualMachine` bound to the default tool registry.
-   【F:src/okcvm/session.py†L18-L44】
-3. The virtual machine converts chat history into LangChain messages, invokes the
-   configured LLM, and records any tool calls or outputs. Results are mapped into
-   the UI-friendly payload returned by `SessionState.respond`. 【F:src/okcvm/vm.py†L58-L118】【F:src/okcvm/session.py†L53-L103】
-4. Frontend requests hit the FastAPI endpoints, which stream back configuration
-   descriptions, session summaries, or chat responses. The UI renders previews,
-   history, and meta telemetry based on the JSON payloads. 【F:src/okcvm/api/main.py†L74-L144】【F:frontend/app.js†L240-L620】
+1. **Server startup** – The Typer CLI (`okcvm.server:cli`) loads layered
+   configuration, validates the workspace directory, prepares logging, and spins
+   up Uvicorn pointed at `okcvm.api.main:app`.【F:src/okcvm/server.py†L1-L88】
+2. **Session boot** – On the first API call, `SessionStore` provisions a new
+   `SessionState` which attaches a `WorkspaceManager`, loads the canonical prompt,
+   and instantiates a `VirtualMachine` bound to the default tool registry.【F:src/okcvm/api/main.py†L58-L209】【F:src/okcvm/session.py†L22-L90】
+3. **Chat execution** – The virtual machine adapts chat history into LangChain
+   message objects, invokes the configured model, records tool calls, and returns
+   a structured payload consumed by the frontend.【F:src/okcvm/vm.py†L58-L178】
+4. **Workspace snapshotting** – After each response, the workspace state takes a
+   Git snapshot and exposes metadata (latest commit, snapshot list, workspace
+   mount paths) via the session object so the UI can render the session tree.【F:src/okcvm/session.py†L94-L207】【F:src/okcvm/workspace.py†L32-L211】
+5. **Frontend rendering** – The browser client fetches configuration and session
+   info, renders conversation threads, writes HTML previews into an iframe, and
+   streams telemetry into the model log timeline.【F:frontend/app.js†L360-L851】
 
-## Testing strategy
+## Data boundaries and storage
 
-A comprehensive `pytest` suite under [`tests/`](../tests) keeps the runtime
-stable. API, VM, registry, and workspace behaviour all have dedicated coverage,
-with fixtures defined in [`tests/conftest.py`](../tests/conftest.py). 【F:tests/test_api_app.py†L1-L120】【F:tests/test_vm.py†L1-L14】【F:tests/test_workspace.py†L1-L24】
+- **Configuration** – In-memory dataclasses represent chat/media endpoints and
+  can be mutated via CLI, YAML, environment variables, or `/api/config`
+  requests.【F:src/okcvm/config.py†L25-L227】【F:src/okcvm/api/main.py†L210-L256】
+- **Session history** – Stored in-process within `VirtualMachine`, including
+  references to tool inputs/outputs and workspace snapshots for branchable
+  timelines.【F:src/okcvm/vm.py†L118-L178】
+- **Workspace** – Each session receives a namespaced directory tree, optionally
+  Git-backed, to isolate file operations and persist artefacts between requests.【F:src/okcvm/workspace.py†L32-L211】
+- **Frontend cache** – `localStorage` holds conversation metadata for quick
+  restoration after reloads; the backend remains stateless beyond workspace
+  directories.【F:frontend/app.js†L1-L360】
+
+## Testing and observability
+
+- `pytest` covers API routes, workspace guarantees, and VM behaviour. The suite
+  lives under [`tests/`](../tests) with fixtures in `conftest.py`.【F:tests/test_api_app.py†L1-L145】【F:tests/test_workspace.py†L1-L24】
+- Structured logs are emitted via `RequestLoggingMiddleware` and the shared
+  logging utilities, enabling trace correlation between API calls and agent
+  activity.【F:src/okcvm/api/main.py†L30-L87】【F:src/okcvm/logging_utils.py†L1-L115】
+
+This layered architecture keeps the project modular: the runtime core can power
+other interfaces, and the frontend can evolve independently while consuming the
+stable API surface.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,41 +1,64 @@
 # Frontend guide
 
-The frontend lives in the [`frontend/`](../frontend) directory and is served as a
-static bundle by FastAPI. It focuses on clarity, offline readiness, and bridging
-API responses into a productive operator workflow.
+The operator console lives in [`frontend/`](../frontend) and is served as a static
+bundle by FastAPI. It focuses on clarity, offline readiness, and presenting agent
+activity in a way that supports rapid iteration.
 
 ## Layout and accessibility
-- [`index.html`](../frontend/index.html) defines a three-pane layout: a history
-  sidebar, chat workspace, and insight column with web/PPT previews. Buttons and
-  interactive regions include ARIA attributes so the panel remains keyboard
-  navigable. 【F:frontend/index.html†L16-L115】
-- The settings overlay ships as an accessible dialog with labelled controls for
-  configuring chat, image, speech, sound-effects, and ASR endpoints. The drawer
-  toggles via the gear button and traps focus while open. 【F:frontend/index.html†L119-L220】
+- [`index.html`](../frontend/index.html) defines a three-pane layout consisting of
+  a history sidebar, chat workspace, and insight column with web/PPT previews.
+  Landmark roles and ARIA attributes ensure the panel stays keyboard navigable,
+  including focus management for dialogs and interactive lists.【F:frontend/index.html†L16-L220】
+- The settings overlay is implemented as an accessible dialog with labelled
+  controls for configuring chat, image, speech, sound-effects, and ASR endpoints.
+  The drawer toggles via the gear button, traps focus while open, and restores
+  focus when dismissed.【F:frontend/index.html†L119-L220】
 
-## State management and storage
-- [`app.js`](../frontend/app.js) initialises DOM references, maintains a
-  `conversations` array, and persists it to `localStorage` via the `storage`
-  wrapper. It normalises conversation payloads, handles history toggling, and
-  syncs the active conversation ID. 【F:frontend/app.js†L1-L360】
-- Conversation rendering keeps pending assistant messages, updates titles based
-  on the latest user input, and bumps the most recent conversation to the top of
-  the list. The UI resets previews when switching sessions to avoid stale
-  content. 【F:frontend/app.js†L360-L480】
+## State management
+- [`app.js`](../frontend/app.js) initialises DOM references, memoises them in a
+  `ui` registry, and coordinates rendering via pure functions rather than heavy
+  frameworks. Conversation state is persisted to `localStorage` using the
+  `storage` helper, allowing tab reloads to restore context instantly.【F:frontend/app.js†L1-L360】
+- The `state` object tracks conversations, active session IDs, pending messages,
+  preview metadata, and configuration status. Mutations go through dedicated
+  reducers (`upsertConversation`, `setActiveConversation`, etc.) so the rendering
+  layer can remain predictable.【F:frontend/app.js†L360-L620】
 
-## Preview rendering and logging
-- The web preview frame and PPT carousel respond to tool outputs returned by the
-  backend. HTML snippets are written into an iframe, while slides populate a
-  template-driven list with toggleable carousel mode. 【F:frontend/app.js†L624-L677】
-- `logModelInvocation` captures the meta telemetry from `/api/chat` responses,
-  capping the timeline to six entries and keeping the empty state in sync.
-  【F:frontend/app.js†L598-L622】
+## Rendering pipeline
+- Conversations render as grouped bubbles with optimistic assistant placeholders.
+  When `/api/chat` resolves, the placeholder is replaced with the final response,
+  previews are refreshed, and the conversation list reorders to keep the most
+  recent threads on top.【F:frontend/app.js†L624-L851】
+- Web previews write HTML into an iframe using `srcdoc`, while slide decks map
+  over returned PPT metadata to render cards and a modal carousel. The UI guards
+  against stale previews by clearing frames whenever the active conversation
+  changes.【F:frontend/app.js†L624-L789】
 
-## Networking and form handling
-- `fetchJson` centralises error handling for backend requests. `populateConfigForm`
-  writes endpoint descriptions into the settings form, while `submitConfigForm`
-  sends updates back to `/api/config` and surfaces success/error states.
-  【F:frontend/app.js†L689-L789】
-- Chat submissions append a pending assistant message, call `/api/chat`, then
-  resolve the placeholder with the final reply and any preview data.
-  【F:frontend/app.js†L810-L851】
+## Networking and error handling
+- `fetchJson` centralises HTTP requests with timeout handling, descriptive error
+  messages, and automatic JSON parsing. It powers configuration, session boot,
+  chat submission, snapshot management, and deployment asset lookups.【F:frontend/app.js†L689-L851】
+- Form helpers (`populateConfigForm`, `submitConfigForm`) sync backend
+  descriptions into the drawer, handle optimistic UI states, and surface toast
+  notifications upon success or failure.【F:frontend/app.js†L689-L789】
+
+## Telemetry and logging
+- `logModelInvocation` captures the meta telemetry returned by `/api/chat`,
+  capping the timeline to six entries, showing token usage, tool invocations, and
+  latency summaries. The empty state is kept in sync when conversations reset.【F:frontend/app.js†L598-L677】
+- A debug console is rendered conditionally when `localStorage.debug` is set,
+  echoing raw payloads to help diagnose integration issues without opening the
+  browser inspector.【F:frontend/app.js†L552-L620】
+
+## Extending the UI
+
+When adding new backend capabilities:
+
+1. Update the `state` shape and provide dedicated render/update helpers rather
+   than mutating DOM nodes inline.
+2. Keep network access wrapped in `fetchJson` so error handling stays
+   consistent.
+3. Reflect new previews in both the main insight pane and the history list to
+   maintain spatial awareness for operators.
+4. Update documentation and alt text to keep the console accessible across
+   screen readers and localisation contexts.

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -1,33 +1,61 @@
-# 工作空间（Workspace）
+# Workspace
 
-OKCVM 为每个会话创建一个隔离的“虚拟空间”，确保工具调用和文件访问始终发生在独立的沙箱中。该机制由 `okcvm.workspace.WorkspaceManager` 驱动，并配合 Git 快照实现可回溯的状态管理。本章节详细描述工作空间的目录结构、生命周期、路径解析策略以及和会话、API 的集成方式。
+OKCVM creates an isolated workspace per session so file-based tools operate inside
+sandboxed directories. The workspace manager also supports Git snapshots, ensuring
+operators can roll back to previous states with confidence.
 
-## 目录结构与初始化
+## Directory structure and initialisation
 
-1. **会话挂载点**：启动时生成随机挂载名（如 `/mnt/okcvm-12ab34cd/`），并在系统临时目录下创建对应的内部根目录。内部目录包含 `mnt/`、`output/`、`tmp/` 子目录，用于分别映射公开挂载、工具输出与临时文件。【F:src/okcvm/workspace.py†L32-L89】
-2. **路径快照**：所有路径被封装在 `WorkspacePaths` 数据类中，包含会话 ID、公开路径（`mount`、`output`）以及内部真实路径，方便在日志和 API 中统一引用。【F:src/okcvm/workspace.py†L168-L211】
-3. **清理机制**：`WorkspaceManager.cleanup()` 会在会话结束或手动重置时递归删除内部根目录，避免跨会话污染。重复调用会被安全地忽略以保证幂等性。【F:src/okcvm/workspace.py†L228-L263】
+1. **Mount points.** `WorkspaceManager` generates a random mount name (e.g.
+   `/mnt/okcvm-12ab34cd/`) and prepares an internal root with `mnt/`, `output/`,
+   and `tmp/` subdirectories for user-visible files, tool outputs, and temporary
+   artefacts.【F:src/okcvm/workspace.py†L32-L118】
+2. **Path dataclass.** `WorkspacePaths` stores the session ID, public mount paths,
+   and absolute filesystem locations so APIs and logs can describe artefacts
+   without leaking internal directory layouts.【F:src/okcvm/workspace.py†L168-L211】
+3. **Cleanup.** `WorkspaceManager.cleanup()` safely removes the internal root when
+   sessions reset, ignoring missing directories to keep operations idempotent.【F:src/okcvm/workspace.py†L228-L264】
 
-## 路径解析与沙箱策略
+## Path resolution and sandboxing
 
-- 所有用户输入的路径都会交给 `WorkspaceManager.resolve()` 处理。该方法会统一分隔符、支持相对路径，并且将所有绝对路径重新定位到当前会话的内部根目录下。如果解析结果试图逃逸根目录，会抛出 `WorkspaceError` 终止操作。【F:src/okcvm/workspace.py†L212-L227】【F:src/okcvm/workspace.py†L242-L264】
-- 为了兼容旧版系统提示词，`WorkspaceManager.adapt_prompt()` 会将提示词中的历史挂载路径（`/mnt/okcomputer/`、`/mnt/okcomputer/output/`）替换为当前会话的随机挂载路径，使得代理始终感知正确的沙箱位置。【F:src/okcvm/workspace.py†L266-L281】
+- All user-supplied paths flow through `WorkspaceManager.resolve()`, which normalises
+  separators, rewrites absolute paths into the session root, and prevents escapes
+  above the workspace directory by raising `WorkspaceError`.【F:src/okcvm/workspace.py†L212-L264】
+- `adapt_prompt()` replaces legacy mount references (e.g. `/mnt/okcomputer/`) in
+  the system prompt so the agent always receives the current session-specific
+  paths.【F:src/okcvm/workspace.py†L266-L281】
 
-## Git 驱动的快照
+## Git-backed snapshots
 
-- `GitWorkspaceState` 会在工作空间根目录下初始化 Git 仓库，并设置隔离的环境变量，确保提交不会污染系统级 Git 配置。若运行环境缺少 Git，可回退到 `_NullWorkspaceState`，此时快照功能被禁用但工作空间依旧可用。【F:src/okcvm/workspace.py†L44-L118】
-- 每次创建快照会执行 `git add -A`、`git commit` 并返回最新的 commit 哈希，以便前端通过会话树引用具体节点。快照条目记录 ID、标签和时间戳，可通过 API 查询最近 N 条历史。【F:src/okcvm/workspace.py†L120-L162】
-- 恢复动作会 `git reset --hard` 指定哈希并清理未跟踪文件，实现可预测的回滚能力；若传入未知哈希，系统会抛出 `WorkspaceStateError` 并阻止恢复。【F:src/okcvm/workspace.py†L156-L167】
+- `GitWorkspaceState` initialises a repository inside the workspace, sets isolated
+  Git environment variables, and provides `snapshot()` / `restore()` helpers.
+  Environments without Git fall back to a null implementation that disables
+  snapshots but keeps the sandbox usable.【F:src/okcvm/workspace.py†L44-L167】
+- Snapshots stage all files, commit with a label derived from the conversation,
+  and return metadata (hash, message, timestamp) for the session tree.【F:src/okcvm/workspace.py†L120-L162】
+- Restoring a snapshot performs `git reset --hard`, cleans untracked files, and
+  raises `WorkspaceStateError` when an unknown hash is provided so callers can
+  surface actionable errors.【F:src/okcvm/workspace.py†L156-L167】
 
-## 会话生命周期中的挂载
+## Session lifecycle integration
 
-1. **创建会话**：`SessionState._initialise_vm()` 调用配置层获得持久根目录，实例化 `WorkspaceManager`，并将其注入默认工具注册表，保证所有声明 `requires_workspace` 的工具自动获得沙箱上下文。【F:src/okcvm/session.py†L22-L44】
-2. **响应消息**：在 `SessionState.respond()` 中，每次回复都会根据用户输入生成快照标签，调用 `workspace.state.snapshot()` 捕捉当前文件状态，并把快照摘要嵌入返回 payload 的 `workspace_state` 字段，供前端渲染会话树节点。【F:src/okcvm/session.py†L94-L150】
-3. **重置与清理**：`SessionState.delete_history()` 和 `SessionState.reset()` 会先调用工作空间清理，再重新初始化 VM 与工作空间，确保旧文件不会影响新会话。【F:src/okcvm/session.py†L152-L207】
+1. **Creation.** `SessionState._initialise_vm()` resolves workspace settings from
+   the global config, instantiates `WorkspaceManager`, injects it into the tool
+   registry, and prepares the virtual machine for the client.【F:src/okcvm/session.py†L22-L90】
+2. **Response handling.** `SessionState.respond()` generates snapshot labels from
+   the latest user message, captures the workspace state, and includes summary
+   metadata in the API response for frontend consumption.【F:src/okcvm/session.py†L94-L150】
+3. **Reset.** `SessionState.delete_history()` and `SessionState.reset()` call
+   `cleanup()` on the workspace, ensuring stale files never leak into new
+   sessions.【F:src/okcvm/session.py†L152-L207】
 
-## API 与工具集成
+## API integration
 
-- FastAPI 提供列出、创建、恢复快照的 REST 接口，分别映射到 `GET /api/session/workspace/snapshots`、`POST /api/session/workspace/snapshots` 与 `POST /api/session/workspace/restore`。错误会统一包装为 `WorkspaceStateError` 并以 400 返回。【F:src/okcvm/api/main.py†L187-L222】
-- 所有需要文件系统的工具（如网站部署、PPT 生成等）都通过注入的 `WorkspaceManager` 解析路径，保证它们的输入输出落在当前会话目录内，并能被后续快照捕获，实现跨工具的一致状态管理。【F:src/okcvm/tools/deployment.py†L70-L116】【F:src/okcvm/tools/slides.py†L32-L73】
+- FastAPI routes list, create, and restore snapshots under `/api/session/workspace/*`,
+  wrapping workspace errors into HTTP 400 responses for clarity.【F:src/okcvm/api/main.py†L267-L309】
+- Tools that require filesystem access receive the workspace manager via dependency
+  injection, guaranteeing their reads/writes stay inside the sandbox and are
+  tracked by subsequent snapshots.【F:src/okcvm/registry.py†L118-L200】【F:src/okcvm/tools/deployment.py†L70-L208】
 
-通过以上机制，工作空间章节保证了在多会话、多工具场景下的数据隔离、安全访问和时间旅行能力，是会话树运作的基础。
+Treat the workspace as the source of truth for artefacts—tests, deployments, and
+previews all rely on its consistency and isolation guarantees.


### PR DESCRIPTION
## Summary
- refresh the roadmap to reflect the current runtime capabilities and upcoming initiatives
- translate and expand the architecture, backend, frontend, session tree, and workspace docs into detailed English guides
- update the docs README with navigation, maintenance guidelines, and an editing checklist

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68e0894de0808321b270e1c562858cad