### PR TITLE
Fix preview URLs to remain accessible from the orchestrator UI

### DIFF
--- a/src/okcvm/session.py
+++ b/src/okcvm/session.py
@@ -109,9 +109,10 @@ class SessionState:
         except ValueError:
             return url
 
-        if not parsed.scheme or not parsed.netloc:
-            # Only augment absolute URLs that point to our orchestrator.
-            return url
+        if parsed.scheme and parsed.netloc:
+            host = parsed.hostname
+            if host and host not in {"127.0.0.1", "localhost", "0.0.0.0"}:
+                return url
 
         query = dict(parse_qsl(parsed.query, keep_blank_values=True))
         if query.get("client_id"):
@@ -119,7 +120,8 @@ class SessionState:
 
         query["client_id"] = client_id
         new_query = urlencode(query, doseq=True)
-        return urlunparse(parsed._replace(query=new_query))
+        updated = parsed._replace(query=new_query)
+        return urlunparse(updated)
 
     def _meta(self, model: str, summary: str) -> Dict[str, str]:
         # 这个方法可以保留，用于生成前端需要的元数据

--- a/src/okcvm/tools/deployment.py
+++ b/src/okcvm/tools/deployment.py
@@ -248,7 +248,7 @@ class DeployWebsiteTool(Tool):
             "session_id": self._workspace.session_id,
         }
 
-        preview_url = f"http://127.0.0.1:8000/?s={deployment_id}&path={quote(entry_path)}"
+        preview_url = f"/?s={deployment_id}&path={quote(entry_path)}"
         manifest["preview_url"] = preview_url
         manifest["entry_path"] = entry_path
 


### PR DESCRIPTION
## Summary
- serve generated deployment preview links as relative orchestrator paths so the web UI can open them from any host
- relax client-id augmentation logic to handle relative preview URLs while ignoring third-party links

## Testing
- pytest tests/test_deployment.py

------
https://chatgpt.com/codex/tasks/task_b_68e08b0295fc8321b88f90e3c416116d