### PR TITLE
Normalize web preview responses and expose preview base configuration

### DIFF
--- a/src/okcvm/config.py
+++ b/src/okcvm/config.py
@@ -91,12 +91,14 @@ class WorkspaceConfig:
 
     path: Optional[str] = None
     confirm_on_start: bool = True
+    preview_base_url: Optional[str] = None
     _config_dir: Optional[Path] = None
 
     def copy(self) -> "WorkspaceConfig":
         return WorkspaceConfig(
             path=self.path,
             confirm_on_start=self.confirm_on_start,
+            preview_base_url=self.preview_base_url,
             _config_dir=self._config_dir,
         )
 
@@ -276,6 +278,7 @@ def _parse_workspace(data: Mapping[str, object] | None, *, config_dir: Path) -> 
 
     path_value: Optional[str] = None
     confirm_on_start = True
+    preview_base_url: Optional[str] = None
 
     if isinstance(data, Mapping):
         raw_path = data.get("path")
@@ -287,9 +290,21 @@ def _parse_workspace(data: Mapping[str, object] | None, *, config_dir: Path) -> 
         if "confirm_on_start" in data:
             confirm_on_start = bool(data.get("confirm_on_start"))
 
+        raw_preview = data.get("preview_base_url")
+        if isinstance(raw_preview, str) and raw_preview.strip():
+            preview_base_url = raw_preview.strip()
+        elif raw_preview not in (None, ""):
+            logger.warning("Ignoring invalid preview_base_url configuration: %s", raw_preview)
+
+    if not preview_base_url:
+        env_preview = os.environ.get("OKCVM_PREVIEW_BASE_URL")
+        if env_preview and env_preview.strip():
+            preview_base_url = env_preview.strip()
+
     workspace = WorkspaceConfig(
         path=path_value,
         confirm_on_start=confirm_on_start,
+        preview_base_url=preview_base_url,
         _config_dir=config_dir,
     )
 

--- a/src/okcvm/workspace.py
+++ b/src/okcvm/workspace.py
@@ -194,6 +194,7 @@ class WorkspaceManager:
         base_dir: Path | str | None = None,
         mount_root: PurePosixPath | str = PurePosixPath("/mnt"),
         prefix: str = "okcvm",
+        preview_base_url: str | None = None,
     ) -> None:
         token = secrets.token_hex(8)
         mount_root_path = (
@@ -229,12 +230,17 @@ class WorkspaceManager:
         self._session_id = mount_path.name
         self._storage_root = storage_root
         self._deployments_root = deployments_root
+        self._preview_base_url = preview_base_url.rstrip("/") if isinstance(preview_base_url, str) else None
         candidate_state = GitWorkspaceState(internal_root)
         self.state = candidate_state if candidate_state.enabled else _NullWorkspaceState()
 
     @property
     def paths(self) -> WorkspacePaths:
         return self._paths
+
+    @property
+    def preview_base_url(self) -> Optional[str]:
+        return self._preview_base_url
 
     @property
     def storage_root(self) -> Path:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -24,6 +24,8 @@ def test_workspace_cleanup_removes_directory(tmp_path: Path) -> None:
     # second call is a no-op
     removed_again = manager.cleanup()
     assert removed_again is False
+
+
 def test_resolve_anchors_generic_absolute_path(tmp_path: Path) -> None:
     """Absolute paths outside the mount are mapped inside the workspace."""
 


### PR DESCRIPTION
## Summary
- add a preview_base_url option to the workspace configuration/manager for resolving deployment previews
- normalize tool outputs so chat responses include absolute web_preview metadata and artifacts entries
- serialize ToolResult observations from the agent to unblock preview parsing on the frontend

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e097441ee48321b24803f0b43a250d