### PR TITLE
Improve preview extraction and configuration for web previews

### DIFF
--- a/src/okcvm/config.py
+++ b/src/okcvm/config.py
@@ -91,12 +91,14 @@ class WorkspaceConfig:
 
     path: Optional[str] = None
     confirm_on_start: bool = True
+    preview_base_url: Optional[str] = None
     _config_dir: Optional[Path] = None
 
     def copy(self) -> "WorkspaceConfig":
         return WorkspaceConfig(
             path=self.path,
             confirm_on_start=self.confirm_on_start,
+            preview_base_url=self.preview_base_url,
             _config_dir=self._config_dir,
         )
 
@@ -276,6 +278,7 @@ def _parse_workspace(data: Mapping[str, object] | None, *, config_dir: Path) -> 
 
     path_value: Optional[str] = None
     confirm_on_start = True
+    preview_base_url: Optional[str] = None
 
     if isinstance(data, Mapping):
         raw_path = data.get("path")
@@ -287,9 +290,16 @@ def _parse_workspace(data: Mapping[str, object] | None, *, config_dir: Path) -> 
         if "confirm_on_start" in data:
             confirm_on_start = bool(data.get("confirm_on_start"))
 
+        raw_preview = data.get("preview_base_url")
+        if isinstance(raw_preview, str) and raw_preview.strip():
+            preview_base_url = raw_preview.strip()
+        elif raw_preview not in (None, ""):
+            logger.warning("Ignoring invalid preview_base_url configuration: %s", raw_preview)
+
     workspace = WorkspaceConfig(
         path=path_value,
         confirm_on_start=confirm_on_start,
+        preview_base_url=preview_base_url,
         _config_dir=config_dir,
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -121,9 +121,26 @@ def test_load_config_from_yaml_supports_env_keys(tmp_path: Path, monkeypatch):
     assert cfg.media.image.api_key == "inline-image"
     assert cfg.media.speech is not None
     assert cfg.media.speech.api_key == "sk-speech"
+    assert cfg.workspace.preview_base_url is None
 
 
 def test_load_config_from_yaml_missing_file_is_noop(tmp_path: Path, capsys):
     config_mod.load_config_from_yaml(tmp_path / "missing.yaml")
     captured = capsys.readouterr().out
     assert "Config file not found" in captured
+
+
+def test_load_config_from_yaml_reads_preview_base_url(tmp_path: Path):
+    payload = {
+        "workspace": {
+            "preview_base_url": "https://preview.invalid/preview",
+        }
+    }
+
+    config_file = tmp_path / "with-preview.yaml"
+    config_file.write_text(config_mod.yaml.safe_dump(payload), encoding="utf-8")
+
+    config_mod.load_config_from_yaml(config_file)
+    cfg = config_mod.get_config()
+
+    assert cfg.workspace.preview_base_url == "https://preview.invalid/preview"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,93 @@
+import json
+from typing import Any, Dict
+
+import pytest
+
+from okcvm import session as session_module
+from okcvm.config import WorkspaceConfig, configure, get_config
+
+
+class DummyVM:
+    def __init__(self, system_prompt: str, registry: Any) -> None:  # noqa: D401 - test stub
+        self.system_prompt = system_prompt
+        self.registry = registry
+        self.history: list[Dict[str, Any]] = []
+        self._response: Dict[str, Any] = {"reply": "", "tool_calls": []}
+
+    def execute(self, message: str) -> Dict[str, Any]:
+        self.history.append({"role": "user", "content": message})
+        reply = self._response.get("reply", "")
+        self.history.append({"role": "assistant", "content": reply})
+        return self._response
+
+    def describe_history(self, limit: int = 25):
+        return self.history[-limit:]
+
+    def discard_last_exchange(self) -> bool:
+        if len(self.history) < 2:
+            return False
+        self.history = self.history[:-2]
+        return True
+
+    def record_history_entry(self, entry: Dict[str, Any]) -> Dict[str, Any]:
+        self.history.append(entry)
+        return entry
+
+    def describe(self) -> Dict[str, Any]:
+        return {"history_length": len(self.history)}
+
+
+@pytest.fixture(autouse=True)
+def restore_config_state():
+    original = get_config()
+    try:
+        yield
+    finally:
+        configure(workspace=original.workspace.copy())
+
+
+def test_session_collects_preview_from_non_terminal_tool(monkeypatch):
+    monkeypatch.setattr(session_module, "VirtualMachine", DummyVM)
+
+    configure(workspace=WorkspaceConfig(preview_base_url="https://preview.invalid"))
+    state = session_module.SessionState()
+    state.attach_client("test-client")
+
+    deployment_payload = {
+        "output": "Deployment complete. Site is ready.",
+        "data": {
+            "deployment_id": "761043",
+            "preview_url": "/?s=761043&path=index.html",
+            "deployment": {
+                "id": "761043",
+                "name": "Hello World",
+                "preview_url": "/?s=761043&path=index.html",
+            },
+        },
+    }
+    write_payload = {
+        "output": "Wrote file /index.html",
+        "data": {"path": "/workspace/index.html"},
+    }
+
+    state.vm._response = {
+        "reply": "done",
+        "tool_calls": [
+            {"tool_name": "mshtools-deploy_website", "tool_output": json.dumps(deployment_payload)},
+            {"tool_name": "mshtools-files_write", "tool_output": json.dumps(write_payload)},
+        ],
+    }
+
+    result = state.respond("create site")
+
+    preview = result["web_preview"]
+    assert preview is not None
+    assert preview["deployment_id"] == "761043"
+    assert preview["title"] == "Hello World"
+    assert preview["url"].startswith("https://preview.invalid/")
+
+    assert result["artifacts"], "expected web artifacts to be returned"
+    assert any(artifact["url"] == preview["url"] for artifact in result["artifacts"])
+
+    assert result["ppt_slides"] == []
+    assert result["meta"]["summary"].startswith("Wrote file")


### PR DESCRIPTION
## Summary
- add an optional `preview_base_url` to the workspace configuration and load it from YAML
- enhance `SessionState.respond` to normalize preview URLs, surface artifacts, and retain PPT slides from tool outputs
- add regression tests covering the new configuration field and preview extraction logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e097441ee48321b24803f0b43a250d