### PR TITLE
Convert documentation citations to GitHub line anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Once configured, you're ready to interact with the agent in the chat interface! 
 
 #### 5. Concurrency & Multi-User Access
 
-The demo FastAPI service keeps a single global `SessionState` instance in [`src/okcvm/api/main.py`](src/okcvm/api/main.py), so every browser tab shares the same conversation and workspace context. There is no automatic per-visitor isolation in this mode.【F:src/okcvm/api/main.py†L63-L69】
+The demo FastAPI service keeps a single global `SessionState` instance in [`src/okcvm/api/main.py`](src/okcvm/api/main.py), so every browser tab shares the same conversation and workspace context. There is no automatic per-visitor isolation in this mode. [src/okcvm/api/main.py#L63-L69](src/okcvm/api/main.py#L63-L69)
 
 To run multi-user or multi-session deployments, allocate a dedicated `SessionState` per user (for example by binding it to an authenticated account or an explicit session ID) and pass that instance into the relevant API routes.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -145,7 +145,7 @@ okcvm-server
 
 #### 5. 并发与多用户访问 (Concurrency & Multi-User Access)
 
-当前的 FastAPI 服务在 `src/okcvm/api/main.py` 中维护了一个全局的 `SessionState` 单例，用于演示目的。也就是说，所有浏览器客户端都会共享同一个对话会话和工作空间，并不会为每位访客自动创建隔离上下文。【F:src/okcvm/api/main.py†L63-L69】
+当前的 FastAPI 服务在 `src/okcvm/api/main.py` 中维护了一个全局的 `SessionState` 单例，用于演示目的。也就是说，所有浏览器客户端都会共享同一个对话会话和工作空间，并不会为每位访客自动创建隔离上下文。 [src/okcvm/api/main.py#L63-L69](src/okcvm/api/main.py#L63-L69)
 
 如果需要支持真正的多用户或多会话并发，你需要在应用层为每位用户分配独立的 `SessionState` 实例（例如基于登录态或显式的会话 ID），并将它们注入到对应的 API 路由中。
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,12 +18,12 @@ together. If you are onboarding, start here before diving into the source tree.
 
 - **Keep docs and code in sync.** Whenever you modify core runtime logic, update
 the corresponding section. The tables above should always reflect the actual
-responsibilities of each module.【F:docs/backend.md†L1-L124】
-- **Link to source.** Inline citations (e.g. `【F:src/...】`) reference canonical
+responsibilities of each module. [docs/backend.md#L1-L124](backend.md#L1-L124)
+- **Link to source.** Inline citations (e.g. `[src/...#L..]`) reference canonical
 implementations so future contributors can audit behaviour quickly.
 - **Prefer English.** All technical documentation is maintained in English to
 serve the global engineering team. Localised product copy belongs in the
-frontend assets or runtime constants.【F:src/okcvm/constants.py†L1-L120】
+frontend assets or runtime constants. [src/okcvm/constants.py#L1-L120](../src/okcvm/constants.py#L1-L120)
 
 ## Editing checklist
 
@@ -33,7 +33,7 @@ frontend assets or runtime constants.【F:src/okcvm/constants.py†L1-L120】
 3. Extend the workspace and session tree guides whenever tools rely on new
    directory layouts or metadata conventions.
 4. Run `pytest` after major changes and record additional learnings in the
-docs if a regression revealed missing context.【F:tests/test_api_app.py†L1-L145】
+docs if a regression revealed missing context. [tests/test_api_app.py#L1-L145](../tests/test_api_app.py#L1-L145)
 
 Treat this directory as part of the codebase—pull requests without matching
 documentation updates should be rare exceptions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,60 +7,59 @@ Python orchestrator, FastAPI API, and static operator console loosely coupled.
 ## Subsystem map
 
 1. **Specification bundle** – The upstream system prompt and tool manifest live
-   in [`spec/system_prompt.md`](../spec/system_prompt.md) and
-   [`spec/tools.json`](../spec/tools.json). `okcvm.spec` exposes dataclasses and
+   in [`spec/system_prompt.md`](../spec/system_prompt.md) and [`spec/tools.json`](../spec/tools.json). `okcvm.spec` exposes dataclasses and
    helpers that parse these assets, providing typed accessors for downstream
-   modules.【F:src/okcvm/spec.py†L1-L168】
+   modules. [src/okcvm/spec.py#L1-L168](../src/okcvm/spec.py#L1-L168)
 2. **Runtime core** – Modules under [`src/okcvm/`](../src/okcvm) handle
    configuration, logging, registry wiring, LangChain integration, workspace
    management, and session lifecycle. They are pure Python and power both the CLI
-   and API surfaces.【F:src/okcvm/config.py†L25-L227】【F:src/okcvm/vm.py†L26-L178】
+   and API surfaces. [src/okcvm/config.py#L25-L227](../src/okcvm/config.py#L25-L227) [src/okcvm/vm.py#L26-L178](../src/okcvm/vm.py#L26-L178)
 3. **HTTP API** – [`okcvm.api.main`](../src/okcvm/api/main.py) wraps FastAPI,
    serves static assets, implements authentication-free REST endpoints, and keeps
-   multi-client session state in-memory via `SessionStore`.【F:src/okcvm/api/main.py†L58-L309】
+   multi-client session state in-memory via `SessionStore`. [src/okcvm/api/main.py#L58-L309](../src/okcvm/api/main.py#L58-L309)
 4. **Control panel frontend** – Static assets in [`frontend/`](../frontend)
    deliver the dashboard experience with persistent conversations, settings
-   management, preview panes, and telemetry timelines.【F:frontend/index.html†L16-L220】【F:frontend/app.js†L1-L851】
+   management, preview panes, and telemetry timelines. [frontend/index.html#L16-L220](../frontend/index.html#L16-L220) [frontend/app.js#L1-L851](../frontend/app.js#L1-L851)
 
 ## Request lifecycle
 
 1. **Server startup** – The Typer CLI (`okcvm.server:cli`) loads layered
    configuration, validates the workspace directory, prepares logging, and spins
-   up Uvicorn pointed at `okcvm.api.main:app`.【F:src/okcvm/server.py†L1-L88】
+   up Uvicorn pointed at `okcvm.api.main:app`. [src/okcvm/server.py#L1-L88](../src/okcvm/server.py#L1-L88)
 2. **Session boot** – On the first API call, `SessionStore` provisions a new
    `SessionState` which attaches a `WorkspaceManager`, loads the canonical prompt,
-   and instantiates a `VirtualMachine` bound to the default tool registry.【F:src/okcvm/api/main.py†L58-L209】【F:src/okcvm/session.py†L22-L90】
+   and instantiates a `VirtualMachine` bound to the default tool registry. [src/okcvm/api/main.py#L58-L209](../src/okcvm/api/main.py#L58-L209) [src/okcvm/session.py#L22-L90](../src/okcvm/session.py#L22-L90)
 3. **Chat execution** – The virtual machine adapts chat history into LangChain
    message objects, invokes the configured model, records tool calls, and returns
-   a structured payload consumed by the frontend.【F:src/okcvm/vm.py†L58-L178】
+   a structured payload consumed by the frontend. [src/okcvm/vm.py#L58-L178](../src/okcvm/vm.py#L58-L178)
 4. **Workspace snapshotting** – After each response, the workspace state takes a
    Git snapshot and exposes metadata (latest commit, snapshot list, workspace
-   mount paths) via the session object so the UI can render the session tree.【F:src/okcvm/session.py†L94-L207】【F:src/okcvm/workspace.py†L32-L211】
+   mount paths) via the session object so the UI can render the session tree. [src/okcvm/session.py#L94-L207](../src/okcvm/session.py#L94-L207) [src/okcvm/workspace.py#L32-L211](../src/okcvm/workspace.py#L32-L211)
 5. **Frontend rendering** – The browser client fetches configuration and session
    info, renders conversation threads, writes HTML previews into an iframe, and
-   streams telemetry into the model log timeline.【F:frontend/app.js†L360-L851】
+   streams telemetry into the model log timeline. [frontend/app.js#L360-L851](../frontend/app.js#L360-L851)
 
 ## Data boundaries and storage
 
 - **Configuration** – In-memory dataclasses represent chat/media endpoints and
   can be mutated via CLI, YAML, environment variables, or `/api/config`
-  requests.【F:src/okcvm/config.py†L25-L227】【F:src/okcvm/api/main.py†L210-L256】
+  requests. [src/okcvm/config.py#L25-L227](../src/okcvm/config.py#L25-L227) [src/okcvm/api/main.py#L210-L256](../src/okcvm/api/main.py#L210-L256)
 - **Session history** – Stored in-process within `VirtualMachine`, including
   references to tool inputs/outputs and workspace snapshots for branchable
-  timelines.【F:src/okcvm/vm.py†L118-L178】
+  timelines. [src/okcvm/vm.py#L118-L178](../src/okcvm/vm.py#L118-L178)
 - **Workspace** – Each session receives a namespaced directory tree, optionally
-  Git-backed, to isolate file operations and persist artefacts between requests.【F:src/okcvm/workspace.py†L32-L211】
+  Git-backed, to isolate file operations and persist artefacts between requests. [src/okcvm/workspace.py#L32-L211](../src/okcvm/workspace.py#L32-L211)
 - **Frontend cache** – `localStorage` holds conversation metadata for quick
   restoration after reloads; the backend remains stateless beyond workspace
-  directories.【F:frontend/app.js†L1-L360】
+  directories. [frontend/app.js#L1-L360](../frontend/app.js#L1-L360)
 
 ## Testing and observability
 
 - `pytest` covers API routes, workspace guarantees, and VM behaviour. The suite
-  lives under [`tests/`](../tests) with fixtures in `conftest.py`.【F:tests/test_api_app.py†L1-L145】【F:tests/test_workspace.py†L1-L24】
+  lives under [`tests/`](../tests) with fixtures in `conftest.py`. [tests/test_api_app.py#L1-L145](../tests/test_api_app.py#L1-L145) [tests/test_workspace.py#L1-L24](../tests/test_workspace.py#L1-L24)
 - Structured logs are emitted via `RequestLoggingMiddleware` and the shared
   logging utilities, enabling trace correlation between API calls and agent
-  activity.【F:src/okcvm/api/main.py†L30-L87】【F:src/okcvm/logging_utils.py†L1-L115】
+  activity. [src/okcvm/api/main.py#L30-L87](../src/okcvm/api/main.py#L30-L87) [src/okcvm/logging_utils.py#L1-L115](../src/okcvm/logging_utils.py#L1-L115)
 
 This layered architecture keeps the project modular: the runtime core can power
 other interfaces, and the frontend can evolve independently while consuming the

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -8,58 +8,56 @@ covers the moving parts you will touch most often when extending the system.
 - [`okcvm.config`](../src/okcvm/config.py) defines dataclasses for chat endpoints,
   media providers, and workspace settings. It supports layered loading from YAML,
   environment variables, and in-memory overrides, exposing thread-safe `configure`
-  and `get_config` helpers for both CLI and API callers.【F:src/okcvm/config.py†L25-L227】
+  and `get_config` helpers for both CLI and API callers. [src/okcvm/config.py#L25-L227](../src/okcvm/config.py#L25-L227)
 - `load_config_from_yaml` resolves relative paths against the project root,
   applies defaults, and prepares workspace directories before runtime
-  initialisation.【F:src/okcvm/config.py†L177-L227】
+  initialisation. [src/okcvm/config.py#L177-L227](../src/okcvm/config.py#L177-L227)
 - The FastAPI `/api/config` route deserialises incoming payloads into the same
   dataclasses, redacts secrets in logs, and reuses `configure` so operators can
-  adjust credentials without restarts.【F:src/okcvm/api/main.py†L210-L256】
+  adjust credentials without restarts. [src/okcvm/api/main.py#L210-L256](../src/okcvm/api/main.py#L210-L256)
 
 ## Tool registry and workspace injection
 - [`okcvm.registry.ToolRegistry`](../src/okcvm/registry.py) parses the packaged
   tool specification, registers Python implementations, and injects a
   `WorkspaceManager` into tools that declare `requires_workspace`, ensuring file
-  operations stay within the session sandbox.【F:src/okcvm/registry.py†L1-L200】
+  operations stay within the session sandbox. [src/okcvm/registry.py#L1-L200](../src/okcvm/registry.py#L1-L200)
 - Custom tools live in [`okcvm/tools`](../src/okcvm/tools). Highlights include
   deployment helpers, slide generation, shell access, and data ingestion stubs.
   Each tool adheres to the manifest schema and often wraps shared helpers from
-  `okcvm.tools.base`.【F:src/okcvm/tools/deployment.py†L40-L208】【F:src/okcvm/tools/slides.py†L12-L78】
+  `okcvm.tools.base`. [src/okcvm/tools/deployment.py#L40-L208](../src/okcvm/tools/deployment.py#L40-L208) [src/okcvm/tools/slides.py#L12-L78](../src/okcvm/tools/slides.py#L12-L78)
 
 ## LangChain integration
 - [`okcvm.llm.create_llm_chain`](../src/okcvm/llm.py) builds a LangChain
   `AgentExecutor` backed by the configured chat model, binds registered tools, and
-  returns a callable used by the virtual machine for every chat turn.【F:src/okcvm/llm.py†L13-L57】
+  returns a callable used by the virtual machine for every chat turn. [src/okcvm/llm.py#L13-L57](../src/okcvm/llm.py#L13-L57)
 - [`okcvm.vm.VirtualMachine`](../src/okcvm/vm.py) stores conversation history,
   lazily constructs the LangChain chain, adapts messages into the required
   structure, records tool invocations, and generates telemetry for the
-  frontend.【F:src/okcvm/vm.py†L26-L178】
+  frontend. [src/okcvm/vm.py#L26-L178](../src/okcvm/vm.py#L26-L178)
 - [`okcvm.session.SessionState`](../src/okcvm/session.py) orchestrates the runtime
   by wiring the registry, VM, and workspace together. It exposes high-level
   methods (`boot`, `respond`, `snapshot_workspace`, etc.) consumed by the API and
-  returns JSON-ready payloads for the frontend.【F:src/okcvm/session.py†L22-L207】
+  returns JSON-ready payloads for the frontend. [src/okcvm/session.py#L22-L207](../src/okcvm/session.py#L22-L207)
 
 ## FastAPI surface
 - [`okcvm.api.main`](../src/okcvm/api/main.py) creates the FastAPI app, mounts the
   static frontend, adds CORS and structured request logging middleware, and keeps
-  track of per-client sessions via `SessionStore`.【F:src/okcvm/api/main.py†L30-L209】
+  track of per-client sessions via `SessionStore`. [src/okcvm/api/main.py#L30-L209](../src/okcvm/api/main.py#L30-L209)
 - REST endpoints expose configuration CRUD, session boot, chat, history lookup,
   workspace snapshot management, and deployment asset serving. Error handling
-  normalises exceptions into HTTP responses with helpful messages for operators.【F:src/okcvm/api/main.py†L210-L309】
+  normalises exceptions into HTTP responses with helpful messages for operators. [src/okcvm/api/main.py#L210-L309](../src/okcvm/api/main.py#L210-L309)
 
 ## Command line interface
 - [`okcvm.server:cli`](../src/okcvm/server.py) is a Typer app that loads
   configuration, verifies workspace paths, and launches Uvicorn. Use
   `python -m okcvm.server --reload` for local development or embed the CLI into
-  supervisor scripts in production.【F:src/okcvm/server.py†L1-L88】
+  supervisor scripts in production. [src/okcvm/server.py#L1-L88](../src/okcvm/server.py#L1-L88)
 - The legacy entrypoint in [`main.py`](../main.py) still exposes Typer commands
-  for compatibility; prefer the dedicated server module for new tooling.【F:main.py†L1-L175】
+  for compatibility; prefer the dedicated server module for new tooling. [main.py#L1-L175](../main.py#L1-L175)
 
 ## Testing
 - `pytest` coverage spans configuration, FastAPI routes, virtual machine
-  behaviour, workspace safety, and tool interactions. Start with
-  [`tests/test_api_app.py`](../tests/test_api_app.py) and
-  [`tests/test_workspace.py`](../tests/test_workspace.py) when debugging
-  regressions.【F:tests/test_api_app.py†L1-L145】【F:tests/test_workspace.py†L1-L24】
+  behaviour, workspace safety, and tool interactions. Start with [`tests/test_api_app.py`](../tests/test_api_app.py) and [`tests/test_workspace.py`](../tests/test_workspace.py) when debugging
+  regressions. [tests/test_api_app.py#L1-L145](../tests/test_api_app.py#L1-L145) [tests/test_workspace.py#L1-L24](../tests/test_workspace.py#L1-L24)
 - Add regression tests alongside new features; the suite runs quickly and is a
   prerequisite for merging into main.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -8,47 +8,47 @@ activity in a way that supports rapid iteration.
 - [`index.html`](../frontend/index.html) defines a three-pane layout consisting of
   a history sidebar, chat workspace, and insight column with web/PPT previews.
   Landmark roles and ARIA attributes ensure the panel stays keyboard navigable,
-  including focus management for dialogs and interactive lists.【F:frontend/index.html†L16-L220】
+  including focus management for dialogs and interactive lists. [frontend/index.html#L16-L220](../frontend/index.html#L16-L220)
 - The settings overlay is implemented as an accessible dialog with labelled
   controls for configuring chat, image, speech, sound-effects, and ASR endpoints.
   The drawer toggles via the gear button, traps focus while open, and restores
-  focus when dismissed.【F:frontend/index.html†L119-L220】
+  focus when dismissed. [frontend/index.html#L119-L220](../frontend/index.html#L119-L220)
 
 ## State management
 - [`app.js`](../frontend/app.js) initialises DOM references, memoises them in a
   `ui` registry, and coordinates rendering via pure functions rather than heavy
   frameworks. Conversation state is persisted to `localStorage` using the
-  `storage` helper, allowing tab reloads to restore context instantly.【F:frontend/app.js†L1-L360】
+  `storage` helper, allowing tab reloads to restore context instantly. [frontend/app.js#L1-L360](../frontend/app.js#L1-L360)
 - The `state` object tracks conversations, active session IDs, pending messages,
   preview metadata, and configuration status. Mutations go through dedicated
   reducers (`upsertConversation`, `setActiveConversation`, etc.) so the rendering
-  layer can remain predictable.【F:frontend/app.js†L360-L620】
+  layer can remain predictable. [frontend/app.js#L360-L620](../frontend/app.js#L360-L620)
 
 ## Rendering pipeline
 - Conversations render as grouped bubbles with optimistic assistant placeholders.
   When `/api/chat` resolves, the placeholder is replaced with the final response,
   previews are refreshed, and the conversation list reorders to keep the most
-  recent threads on top.【F:frontend/app.js†L624-L851】
+  recent threads on top. [frontend/app.js#L624-L851](../frontend/app.js#L624-L851)
 - Web previews write HTML into an iframe using `srcdoc`, while slide decks map
   over returned PPT metadata to render cards and a modal carousel. The UI guards
   against stale previews by clearing frames whenever the active conversation
-  changes.【F:frontend/app.js†L624-L789】
+  changes. [frontend/app.js#L624-L789](../frontend/app.js#L624-L789)
 
 ## Networking and error handling
 - `fetchJson` centralises HTTP requests with timeout handling, descriptive error
   messages, and automatic JSON parsing. It powers configuration, session boot,
-  chat submission, snapshot management, and deployment asset lookups.【F:frontend/app.js†L689-L851】
+  chat submission, snapshot management, and deployment asset lookups. [frontend/app.js#L689-L851](../frontend/app.js#L689-L851)
 - Form helpers (`populateConfigForm`, `submitConfigForm`) sync backend
   descriptions into the drawer, handle optimistic UI states, and surface toast
-  notifications upon success or failure.【F:frontend/app.js†L689-L789】
+  notifications upon success or failure. [frontend/app.js#L689-L789](../frontend/app.js#L689-L789)
 
 ## Telemetry and logging
 - `logModelInvocation` captures the meta telemetry returned by `/api/chat`,
   capping the timeline to six entries, showing token usage, tool invocations, and
-  latency summaries. The empty state is kept in sync when conversations reset.【F:frontend/app.js†L598-L677】
+  latency summaries. The empty state is kept in sync when conversations reset. [frontend/app.js#L598-L677](../frontend/app.js#L598-L677)
 - A debug console is rendered conditionally when `localStorage.debug` is set,
   echoing raw payloads to help diagnose integration issues without opening the
-  browser inspector.【F:frontend/app.js†L552-L620】
+  browser inspector. [frontend/app.js#L552-L620](../frontend/app.js#L552-L620)
 
 ## Extending the UI
 

--- a/docs/session_tree.md
+++ b/docs/session_tree.md
@@ -9,41 +9,41 @@ and audit multi-turn projects without losing context.
 1. **Root node – Session metadata.** `SessionState.boot()` seeds the tree with the
    welcome message, workspace descriptors, and virtual machine summary. Resetting
    history or the workspace clears this root and triggers a fresh initialisation
-   on the next request.【F:src/okcvm/session.py†L22-L207】
+   on the next request. [src/okcvm/session.py#L22-L207](../src/okcvm/session.py#L22-L207)
 2. **Conversation nodes – Message history.** `VirtualMachine.record_history_entry`
    generates deterministic IDs (e.g. `okcvm-12ab34cd-0001`) for each exchange,
    storing message content, tool traces, and metadata. `/api/session/history/{id}`
-   returns any node so the frontend can render branches and tool details.【F:src/okcvm/vm.py†L58-L178】【F:src/okcvm/api/main.py†L257-L309】
+   returns any node so the frontend can render branches and tool details. [src/okcvm/vm.py#L58-L178](../src/okcvm/vm.py#L58-L178) [src/okcvm/api/main.py#L257-L309](../src/okcvm/api/main.py#L257-L309)
 3. **Artefact nodes – Tool outputs.** When the agent calls a tool, the input,
    output, and status are persisted alongside the message so deployments, slide
-   decks, and files appear as children in the tree for later inspection.【F:src/okcvm/vm.py†L118-L178】
+   decks, and files appear as children in the tree for later inspection. [src/okcvm/vm.py#L118-L178](../src/okcvm/vm.py#L118-L178)
 
 ## Snapshot workflow
 
 - `SessionState.respond()` labels each snapshot using the user prompt, then calls
   `workspace.state.snapshot()` to commit filesystem changes. The response embeds
-  the commit hash and recent history so the UI can annotate the timeline.【F:src/okcvm/session.py†L94-L150】【F:src/okcvm/workspace.py†L120-L162】
+  the commit hash and recent history so the UI can annotate the timeline. [src/okcvm/session.py#L94-L150](../src/okcvm/session.py#L94-L150) [src/okcvm/workspace.py#L120-L162](../src/okcvm/workspace.py#L120-L162)
 - `SessionState.restore_workspace()` applies `git reset --hard` to a requested
   hash and refreshes the workspace metadata returned to the client. Errors bubble
-  up as `WorkspaceStateError`, which the API converts to HTTP 400 responses.【F:src/okcvm/session.py†L180-L207】【F:src/okcvm/workspace.py†L156-L167】【F:src/okcvm/api/main.py†L283-L309】
+  up as `WorkspaceStateError`, which the API converts to HTTP 400 responses. [src/okcvm/session.py#L180-L207](../src/okcvm/session.py#L180-L207) [src/okcvm/workspace.py#L156-L167](../src/okcvm/workspace.py#L156-L167) [src/okcvm/api/main.py#L283-L309](../src/okcvm/api/main.py#L283-L309)
 
 ## Linking workspaces and history
 
 - Each history node references the active workspace ID and mount paths via
   `VirtualMachine.describe()`. `/api/session/info` exposes these values so the UI
-  can show the correct sandbox when operators jump between branches.【F:src/okcvm/vm.py†L158-L207】【F:src/okcvm/api/main.py†L233-L256】
+  can show the correct sandbox when operators jump between branches. [src/okcvm/vm.py#L158-L207](../src/okcvm/vm.py#L158-L207) [src/okcvm/api/main.py#L233-L256](../src/okcvm/api/main.py#L233-L256)
 - Tool implementations receive the injected `WorkspaceManager`, write outputs to
   namespaced directories (e.g. `deployments/`, `generated_slides/`), and include
-  session IDs in their metadata for cross-branch auditing.【F:src/okcvm/tools/deployment.py†L70-L208】【F:src/okcvm/tools/slides.py†L12-L78】
+  session IDs in their metadata for cross-branch auditing. [src/okcvm/tools/deployment.py#L70-L208](../src/okcvm/tools/deployment.py#L70-L208) [src/okcvm/tools/slides.py#L12-L78](../src/okcvm/tools/slides.py#L12-L78)
 
 ## Reset and cleanup
 
 1. **Selective rollback.** Calling `/api/session/workspace/restore` rewinds the
    filesystem to a chosen snapshot but keeps the chat history intact, enabling
-   experimentation without losing conversation branches.【F:src/okcvm/api/main.py†L283-L309】
+   experimentation without losing conversation branches. [src/okcvm/api/main.py#L283-L309](../src/okcvm/api/main.py#L283-L309)
 2. **Full reset.** `/api/session/history` with DELETE wipes the VM history and
    removes the workspace directory. The next interaction reinitialises the root
-   node and provisions a new sandbox.【F:src/okcvm/api/main.py†L267-L282】【F:src/okcvm/session.py†L152-L207】
+   node and provisions a new sandbox. [src/okcvm/api/main.py#L267-L282](../src/okcvm/api/main.py#L267-L282) [src/okcvm/session.py#L152-L207](../src/okcvm/session.py#L152-L207)
 
 ## Best practices
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -9,53 +9,53 @@ operators can roll back to previous states with confidence.
 1. **Mount points.** `WorkspaceManager` generates a random mount name (e.g.
    `/mnt/okcvm-12ab34cd/`) and prepares an internal root with `mnt/`, `output/`,
    and `tmp/` subdirectories for user-visible files, tool outputs, and temporary
-   artefacts.【F:src/okcvm/workspace.py†L32-L118】
+   artefacts. [src/okcvm/workspace.py#L32-L118](../src/okcvm/workspace.py#L32-L118)
 2. **Path dataclass.** `WorkspacePaths` stores the session ID, public mount paths,
    and absolute filesystem locations so APIs and logs can describe artefacts
-   without leaking internal directory layouts.【F:src/okcvm/workspace.py†L168-L211】
+   without leaking internal directory layouts. [src/okcvm/workspace.py#L168-L211](../src/okcvm/workspace.py#L168-L211)
 3. **Cleanup.** `WorkspaceManager.cleanup()` safely removes the internal root when
-   sessions reset, ignoring missing directories to keep operations idempotent.【F:src/okcvm/workspace.py†L228-L264】
+   sessions reset, ignoring missing directories to keep operations idempotent. [src/okcvm/workspace.py#L228-L264](../src/okcvm/workspace.py#L228-L264)
 
 ## Path resolution and sandboxing
 
 - All user-supplied paths flow through `WorkspaceManager.resolve()`, which normalises
   separators, rewrites absolute paths into the session root, and prevents escapes
-  above the workspace directory by raising `WorkspaceError`.【F:src/okcvm/workspace.py†L212-L264】
+  above the workspace directory by raising `WorkspaceError`. [src/okcvm/workspace.py#L212-L264](../src/okcvm/workspace.py#L212-L264)
 - `adapt_prompt()` replaces legacy mount references (e.g. `/mnt/okcomputer/`) in
   the system prompt so the agent always receives the current session-specific
-  paths.【F:src/okcvm/workspace.py†L266-L281】
+  paths. [src/okcvm/workspace.py#L266-L281](../src/okcvm/workspace.py#L266-L281)
 
 ## Git-backed snapshots
 
 - `GitWorkspaceState` initialises a repository inside the workspace, sets isolated
   Git environment variables, and provides `snapshot()` / `restore()` helpers.
   Environments without Git fall back to a null implementation that disables
-  snapshots but keeps the sandbox usable.【F:src/okcvm/workspace.py†L44-L167】
+  snapshots but keeps the sandbox usable. [src/okcvm/workspace.py#L44-L167](../src/okcvm/workspace.py#L44-L167)
 - Snapshots stage all files, commit with a label derived from the conversation,
-  and return metadata (hash, message, timestamp) for the session tree.【F:src/okcvm/workspace.py†L120-L162】
+  and return metadata (hash, message, timestamp) for the session tree. [src/okcvm/workspace.py#L120-L162](../src/okcvm/workspace.py#L120-L162)
 - Restoring a snapshot performs `git reset --hard`, cleans untracked files, and
   raises `WorkspaceStateError` when an unknown hash is provided so callers can
-  surface actionable errors.【F:src/okcvm/workspace.py†L156-L167】
+  surface actionable errors. [src/okcvm/workspace.py#L156-L167](../src/okcvm/workspace.py#L156-L167)
 
 ## Session lifecycle integration
 
 1. **Creation.** `SessionState._initialise_vm()` resolves workspace settings from
    the global config, instantiates `WorkspaceManager`, injects it into the tool
-   registry, and prepares the virtual machine for the client.【F:src/okcvm/session.py†L22-L90】
+   registry, and prepares the virtual machine for the client. [src/okcvm/session.py#L22-L90](../src/okcvm/session.py#L22-L90)
 2. **Response handling.** `SessionState.respond()` generates snapshot labels from
    the latest user message, captures the workspace state, and includes summary
-   metadata in the API response for frontend consumption.【F:src/okcvm/session.py†L94-L150】
+   metadata in the API response for frontend consumption. [src/okcvm/session.py#L94-L150](../src/okcvm/session.py#L94-L150)
 3. **Reset.** `SessionState.delete_history()` and `SessionState.reset()` call
    `cleanup()` on the workspace, ensuring stale files never leak into new
-   sessions.【F:src/okcvm/session.py†L152-L207】
+   sessions. [src/okcvm/session.py#L152-L207](../src/okcvm/session.py#L152-L207)
 
 ## API integration
 
 - FastAPI routes list, create, and restore snapshots under `/api/session/workspace/*`,
-  wrapping workspace errors into HTTP 400 responses for clarity.【F:src/okcvm/api/main.py†L267-L309】
+  wrapping workspace errors into HTTP 400 responses for clarity. [src/okcvm/api/main.py#L267-L309](../src/okcvm/api/main.py#L267-L309)
 - Tools that require filesystem access receive the workspace manager via dependency
   injection, guaranteeing their reads/writes stay inside the sandbox and are
-  tracked by subsequent snapshots.【F:src/okcvm/registry.py†L118-L200】【F:src/okcvm/tools/deployment.py†L70-L208】
+  tracked by subsequent snapshots. [src/okcvm/registry.py#L118-L200](../src/okcvm/registry.py#L118-L200) [src/okcvm/tools/deployment.py#L70-L208](../src/okcvm/tools/deployment.py#L70-L208)
 
 Treat the workspace as the source of truth for artefacts—tests, deployments, and
 previews all rely on its consistency and isolation guarantees.

--- a/roadmap.md
+++ b/roadmap.md
@@ -9,42 +9,42 @@ living document—update it whenever major capabilities land or priorities shift
 ### Production-ready runtime and observability
 - FastAPI now powers the public surface, complete with CORS support, structured
   request logging, and static hosting for the operator console so deployments are
-  inspectable with minimal configuration.【F:src/okcvm/api/main.py†L30-L209】
+  inspectable with minimal configuration. [src/okcvm/api/main.py#L30-L209](src/okcvm/api/main.py#L30-L209)
 - The logging stack wires Rich console handlers and rotating file output, making
-  API and agent traces actionable during incident response.【F:src/okcvm/logging_utils.py†L1-L115】
+  API and agent traces actionable during incident response. [src/okcvm/logging_utils.py#L1-L115](src/okcvm/logging_utils.py#L1-L115)
 
 ### Virtual machine orchestration and tooling
 - The LangChain-backed `VirtualMachine` streams conversation history into a tool
-  aware agent executor and records the trace required by the UI’s model log.【F:src/okcvm/vm.py†L26-L178】
+  aware agent executor and records the trace required by the UI’s model log. [src/okcvm/vm.py#L26-L178](src/okcvm/vm.py#L26-L178)
 - `ToolRegistry` loads the canonical tool manifest, injects workspace-aware
   helpers, and exposes LangChain-compatible wrappers, closing the loop between
-  packaged specifications and runtime behaviour.【F:src/okcvm/registry.py†L1-L200】
+  packaged specifications and runtime behaviour. [src/okcvm/registry.py#L1-L200](src/okcvm/registry.py#L1-L200)
 
 ### Session isolation and workspace lifecycle
 - Every client receives an isolated `WorkspaceManager` that rewrites prompt
   mounts, restricts filesystem access, and snapshots state through Git-backed
-  commits for time-travel debugging.【F:src/okcvm/session.py†L22-L207】【F:src/okcvm/workspace.py†L32-L281】
+  commits for time-travel debugging. [src/okcvm/session.py#L22-L207](src/okcvm/session.py#L22-L207) [src/okcvm/workspace.py#L32-L281](src/okcvm/workspace.py#L32-L281)
 - Snapshot creation, listing, and restoration are exposed as first-class API
   endpoints so the frontend can drive the session tree UI without bespoke glue
-  code.【F:src/okcvm/api/main.py†L210-L309】
+  code. [src/okcvm/api/main.py#L210-L309](src/okcvm/api/main.py#L210-L309)
 
 ### Operator experience and automation
 - A Typer CLI now launches the FastAPI server, validates configuration, and
   resolves workspace directories before Uvicorn starts, smoothing local and
-  production workflows.【F:src/okcvm/server.py†L1-L88】
+  production workflows. [src/okcvm/server.py#L1-L88](src/okcvm/server.py#L1-L88)
 - Configuration dataclasses centralise chat and media credentials, providing
-  atomic updates from YAML, environment variables, or API requests.【F:src/okcvm/config.py†L25-L227】
+  atomic updates from YAML, environment variables, or API requests. [src/okcvm/config.py#L25-L227](src/okcvm/config.py#L25-L227)
 
 ### Control panel and presentation layer
 - The static frontend introduces persistent conversations, configuration
   management, live previews for HTML/PPT assets, and a model telemetry timeline
-  that mirrors the VM trace.【F:frontend/index.html†L16-L220】【F:frontend/app.js†L1-L851】
+  that mirrors the VM trace. [frontend/index.html#L16-L220](frontend/index.html#L16-L220) [frontend/app.js#L1-L851](frontend/app.js#L1-L851)
 - Deployment assets are now served directly from per-session directories, giving
-  the preview UI predictable URLs for websites and other artefacts.【F:src/okcvm/api/main.py†L146-L209】
+  the preview UI predictable URLs for websites and other artefacts. [src/okcvm/api/main.py#L146-L209](src/okcvm/api/main.py#L146-L209)
 
 ### Quality and safety net
 - The pytest suite exercises API routes, workspace guarantees, and LangChain
-  integration so regressions surface quickly during CI.【F:tests/test_api_app.py†L1-L145】【F:tests/test_workspace.py†L1-L24】
+  integration so regressions surface quickly during CI. [tests/test_api_app.py#L1-L145](tests/test_api_app.py#L1-L145) [tests/test_workspace.py#L1-L24](tests/test_workspace.py#L1-L24)
 
 ## Active Initiatives
 
@@ -64,7 +64,7 @@ agnostic of tool specifics.
 The API already accepts caller-provided client IDs. We plan to extend this with
 persistent storage and eviction policies so teams can resume workspaces across
 restarts, expire dormant sessions, and safely share deployments between
-operators.【F:src/okcvm/api/main.py†L58-L145】
+operators. [src/okcvm/api/main.py#L58-L145](src/okcvm/api/main.py#L58-L145)
 
 ## Future Exploration
 


### PR DESCRIPTION
## Summary
- replace all static 【F:...†L..】 citations in docs with clickable GitHub line anchor links
- update inline guidance in docs/README.md to reference the new citation format

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e09ee608148321b4a64ad488ebafe1