### PR TITLE
Fix deployment preview URLs and add tests

### DIFF
--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -87,6 +87,9 @@ def test_deploy_website_and_start_server(tmp_path, deployed_site_pid):
     pid = server_info["pid"]
     port = server_info["port"]
     preview_url = manifest_data["preview_url"]
+    preview_path = manifest_data["preview_path"]
+    assert preview_path == f"/?s={manifest_data['id']}&path=index.html"
+    assert preview_url.startswith("http://127.0.0.1:")
     assert preview_url.endswith("&path=index.html")
     server_preview_url = manifest_data.get("server_preview_url")
     assert server_preview_url is not None
@@ -138,7 +141,9 @@ def test_deploy_website_without_starting_server(tmp_path):
     # 验证没有服务器信息
     assert manifest_data["server_info"] is None
     assert manifest_data.get("server_preview_url") is None
+    assert manifest_data["preview_path"].endswith("&path=index.html")
     assert manifest_data["preview_url"].endswith("&path=index.html")
+    assert manifest_data["preview_url"].startswith("/?s=")
     # 验证 PID 不存在（以防万一）
     assert not psutil.pid_exists(manifest_data.get("server_info", {}).get("pid", -1))
 


### PR DESCRIPTION
## Summary
- record LangChain tool invocation payloads so session responses can surface web previews even without intermediate steps
- update the deployment tool to expose a preview_path and build absolute preview URLs when possible
- expand session and deployment tests to cover the new preview handling paths

## Testing
- pytest tests/test_session.py::test_session_collects_preview_from_non_terminal_tool
- pytest tests/test_session.py::test_session_collects_preview_without_intermediate_steps
- pytest tests/test_deployment.py::test_deploy_website_and_start_server
- pytest tests/test_deployment.py::test_deploy_website_without_starting_server
- pytest tests/test_deployment.py::test_deploy_website_creates_index_from_single_html

------
https://chatgpt.com/codex/tasks/task_b_68e09e79d9e08321836576690d073366