### PR TITLE
Fix config update semantics and clarify docs

### DIFF
--- a/spec/interfaces/README.md
+++ b/spec/interfaces/README.md
@@ -9,11 +9,11 @@
 
 ## 客户端标识（`client_id`）
 后端会为每一个逻辑会话维护独立的工作空间与历史记录。服务器通过以下优先级解析客户端标识：
-1. 显式传入的查询参数 `client_id`
-2. HTTP 头 `x-okc-client-id`
-3. Cookie `okc_client_id`
-4. 查询参数 `client_id`
-5. 默认值 `default`
+1. FastAPI 解析到的 `client_id` 参数（例如查询字符串或路由参数显式声明）。
+2. HTTP 头 `x-okc-client-id`。
+3. Cookie `okc_client_id`。
+4. 查询字符串中剩余的 `client_id` 值（兜底检查）。
+5. 默认值 `default`。
 
 客户端可任选一种方式传递标识，推荐在浏览器环境下使用 Cookie，并在需要跨标签共享状态时使用 HTTP 头。所有会返回带链接的字段（如预览地址、工件下载地址）都会自动补全 `client_id` 查询参数，以便前端在同一会话上下文内继续访问。
 

--- a/spec/interfaces/configuration.md
+++ b/spec/interfaces/configuration.md
@@ -27,13 +27,18 @@
 
 | 字段 | 类型 | 说明 |
 | --- | --- | --- |
-| `chat` | `object` | （可选）聊天模型配置。字段为 `model`、`base_url`、`api_key`。若 `model` 或 `base_url` 留空，则视为删除该配置。|
-| `image` | `object` | （可选）图像生成端点配置。结构同上。|
-| `speech` | `object` | （可选）语音合成端点配置。|
-| `sound_effects` | `object` | （可选）音效端点配置。|
-| `asr` | `object` | （可选）语音识别端点配置。|
+| `chat` | `object \| null` | （可选）聊天模型配置。字段为 `model`、`base_url`、`api_key`。显式提交 `null` 或者 `model`/`base_url` 为空字符串会清除该段配置。|
+| `image` | `object \| null` | （可选）图像生成端点配置。结构同上。|
+| `speech` | `object \| null` | （可选）语音合成端点配置。|
+| `sound_effects` | `object \| null` | （可选）音效端点配置。|
+| `asr` | `object \| null` | （可选）语音识别端点配置。|
 
 > **提示**：服务器会在日志中打点更新内容，并在返回体中隐藏任何明文 API Key，方便审计同时避免泄漏。
+
+- **部分更新规则**：
+  1. 仅当请求体显式携带对应字段时才会修改该段配置；缺省字段会沿用现有值。
+  2. `api_key` 字段留空或缺省时，服务器会继续沿用已保存的密钥；若希望清除密钥，请显式传入空字符串。
+  3. 端点对象中缺少 `model` 或 `base_url` 会被视为删除该段配置。
 
 - **响应体**：同 `GET /api/config`。
 - **错误码**：当字段缺失或值非法导致配置更新失败时返回 `400 Bad Request`，`detail` 字段包含失败原因。

--- a/src/okcvm/api/models.py
+++ b/src/okcvm/api/models.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from ..config import MediaConfig, ModelEndpointConfig
+from ..config import ModelEndpointConfig
 
 
 class EndpointConfigPayload(BaseModel):
@@ -61,13 +61,3 @@ class SnapshotRestorePayload(BaseModel):
     """Payload to restore the workspace to an earlier snapshot."""
 
     snapshot_id: str = Field(..., description="Git commit identifier to restore")
-
-
-def build_media_config(payload: ConfigUpdatePayload) -> MediaConfig:
-    """Helper to build MediaConfig from a payload."""
-    return MediaConfig(
-        image=payload.image.to_model() if payload.image else None,
-        speech=payload.speech.to_model() if payload.speech else None,
-        sound_effects=payload.sound_effects.to_model() if payload.sound_effects else None,
-        asr=payload.asr.to_model() if payload.asr else None,
-    )


### PR DESCRIPTION
## Summary
- ensure the /api/config endpoint only mutates sections that are explicitly provided and preserves stored API keys unless a replacement is supplied
- document the partial update and clearing behaviour for configuration payloads and correct the client_id resolution order in the interface guide

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e0a523c48883219eed82186cbc98d7