### PR TITLE
Fix sandbox mode for in-app web previews

### DIFF
--- a/frontend/previews.js
+++ b/frontend/previews.js
@@ -152,6 +152,8 @@ export function updateWebPreview(preview) {
 
   if (hasUrl) {
     if (webPreviewFrame) {
+      applyPreviewSandbox('url');
+      webPreviewFrame.srcdoc = '';
       webPreviewFrame.src = normalizedPreview.url;
       webPreviewFrame.hidden = false;
     }


### PR DESCRIPTION
## Summary
- ensure the embedded preview iframe switches to the correct sandbox mode when loading URLs
- clear any previous inline content before navigating to external preview URLs so the frame renders properly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e0cd611d148321a80e1afc9d088cf6