### PR TITLE
Fix iframe sandbox handling for URL previews

### DIFF
--- a/frontend/previews.js
+++ b/frontend/previews.js
@@ -152,6 +152,7 @@ export function updateWebPreview(preview) {
 
   if (hasUrl) {
     if (webPreviewFrame) {
+      applyPreviewSandbox('url');
       webPreviewFrame.src = normalizedPreview.url;
       webPreviewFrame.hidden = false;
     }
@@ -164,17 +165,6 @@ export function updateWebPreview(preview) {
       applyPreviewSandbox('html');
       webPreviewFrame.src = 'about:blank';
       webPreviewFrame.srcdoc = normalizedPreview.html;
-      webPreviewFrame.hidden = false;
-    }
-    if (webPreviewEmpty) {
-      webPreviewEmpty.hidden = true;
-      webPreviewEmpty.textContent = defaultWebPreviewEmptyMessage;
-    }
-  } else if (hasUrl) {
-    if (webPreviewFrame) {
-      applyPreviewSandbox('url');
-      webPreviewFrame.srcdoc = '';
-      webPreviewFrame.src = normalizedPreview.url;
       webPreviewFrame.hidden = false;
     }
     if (webPreviewEmpty) {


### PR DESCRIPTION
## Summary
- ensure iframe previews that use a URL remove the sandbox restriction
- drop unreachable fallback branch now that sandbox handling is consolidated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e0cd611d148321a80e1afc9d088cf6