### PR TITLE
Expose tool call details in model activity panel

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -273,6 +273,7 @@
           <time class="model-time"></time>
         </header>
         <p class="model-summary"></p>
+        <ul class="tool-call-list" hidden></ul>
         <dl class="model-meta">
           <div>
             <dt>输入 Token</dt>

--- a/frontend/previews.js
+++ b/frontend/previews.js
@@ -38,6 +38,75 @@ export function logModelInvocation(meta) {
     clone.querySelector('.model-name').textContent = log.model;
     clone.querySelector('.model-time').textContent = log.timestamp;
     clone.querySelector('.model-summary').textContent = log.summary;
+
+    const toolList = clone.querySelector('.tool-call-list');
+    if (toolList) {
+      toolList.innerHTML = '';
+      const toolCalls = Array.isArray(log.toolCalls)
+        ? log.toolCalls.filter((item) => item && typeof item === 'object')
+        : [];
+      if (toolCalls.length > 0) {
+        toolList.hidden = false;
+        toolCalls.forEach((call) => {
+          const details = document.createElement('details');
+          details.className = 'tool-call-entry';
+
+          const summary = document.createElement('summary');
+          summary.className = 'tool-call-summary';
+          const name = typeof call.name === 'string' && call.name.trim() ? call.name.trim() : '工具调用';
+          summary.innerHTML = `<span class="tool-call-name">🔧 ${name}</span>`;
+          if (typeof call.source === 'string' && call.source.trim()) {
+            const source = document.createElement('span');
+            source.className = 'tool-call-source';
+            source.textContent = call.source.trim();
+            summary.appendChild(source);
+          }
+          details.appendChild(summary);
+
+          const content = document.createElement('div');
+          content.className = 'tool-call-content';
+
+          if (typeof call.arguments === 'string' && call.arguments.trim()) {
+            const argsBlock = document.createElement('div');
+            argsBlock.className = 'tool-call-block';
+            const argsLabel = document.createElement('span');
+            argsLabel.className = 'tool-call-label';
+            argsLabel.textContent = '输入参数';
+            const argsValue = document.createElement('code');
+            argsValue.className = 'tool-call-value';
+            argsValue.textContent = call.arguments.trim();
+            argsBlock.append(argsLabel, argsValue);
+            content.appendChild(argsBlock);
+          }
+
+          if (typeof call.output === 'string' && call.output.trim()) {
+            const outputBlock = document.createElement('div');
+            outputBlock.className = 'tool-call-block';
+            const outputLabel = document.createElement('span');
+            outputLabel.className = 'tool-call-label';
+            outputLabel.textContent = '执行结果';
+            const outputValue = document.createElement('code');
+            outputValue.className = 'tool-call-value';
+            outputValue.textContent = call.output.trim();
+            outputBlock.append(outputLabel, outputValue);
+            content.appendChild(outputBlock);
+          }
+
+          if (!content.childNodes.length) {
+            const empty = document.createElement('p');
+            empty.className = 'tool-call-empty';
+            empty.textContent = '该工具调用未返回额外信息。';
+            content.appendChild(empty);
+          }
+
+          details.appendChild(content);
+          toolList.appendChild(details);
+        });
+      } else {
+        toolList.hidden = true;
+      }
+    }
+
     clone.querySelector('.meta-input').textContent = log.tokensIn;
     clone.querySelector('.meta-output').textContent = log.tokensOut;
     clone.querySelector('.meta-latency').textContent = log.latency;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -717,6 +717,73 @@ body.no-scroll { overflow: hidden; }
 .model-log-item header { display: flex; align-items: center; justify-content: space-between; font-size: 0.8rem; color: var(--text-tertiary); }
 .model-name { font-weight: 600; color: var(--accent-color); }
 .model-summary { margin: 0; font-size: 0.9rem; line-height: 1.5; color: var(--text-secondary); }
+.tool-call-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+}
+.tool-call-entry {
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  background: var(--bg-panel);
+  overflow: hidden;
+}
+.tool-call-entry[open] {
+  box-shadow: var(--shadow-soft);
+}
+.tool-call-summary {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  padding: 0.6rem 0.75rem;
+  color: var(--text-primary);
+}
+.tool-call-summary::-webkit-details-marker {
+  display: none;
+}
+.tool-call-name {
+  font-weight: 600;
+}
+.tool-call-source {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+.tool-call-content {
+  padding: 0.6rem 0.75rem 0.75rem;
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+.tool-call-block {
+  display: grid;
+  gap: 0.25rem;
+}
+.tool-call-label {
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+.tool-call-value {
+  display: block;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-primary);
+}
+.tool-call-empty {
+  margin: 0;
+  font-style: italic;
+  color: var(--text-tertiary);
+}
 .model-meta { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.75rem; margin: 0; }
 .model-meta dt { font-size: 0.7rem; color: var(--text-tertiary); }
 .model-meta dd { margin: 0.15rem 0 0; font-weight: 600; color: var(--text-primary); }

--- a/src/okcvm/api/main.py
+++ b/src/okcvm/api/main.py
@@ -13,7 +13,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
-from ..config import ModelEndpointConfig, configure, get_config
+from ..config import MediaConfig, ModelEndpointConfig, configure, get_config
 from ..logging_utils import get_logger, setup_logging
 from ..session import SessionState
 from ..workspace import WorkspaceStateError


### PR DESCRIPTION
## Summary
- include structured tool call metadata in session responses so the UI can surface each invocation
- render detailed tool call entries in the "当前模型调用" panel with expandable formatting and new styles
- fix the FastAPI app import so media configuration updates continue to work

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e0d3bdb2188321baceef50eba57bea