### PR TITLE
Add slide outlines to PPT generator output

### DIFF
--- a/tests/test_tools_slides.py
+++ b/tests/test_tools_slides.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from okcvm import ToolRegistry
+
+
+def test_slides_generator_returns_preview(tmp_path):
+    registry = ToolRegistry.from_default_spec()
+    html = """
+    <html>
+      <body>
+        <section class=\"ppt-slide\">
+          <h2>Overview</h2>
+          <p>Intro paragraph</p>
+          <ul>
+            <li>First point</li>
+            <li>Second point</li>
+          </ul>
+        </section>
+        <section class=\"ppt-slide\">
+          <p>Next steps</p>
+          <p>Timeline</p>
+        </section>
+      </body>
+    </html>
+    """
+
+    output_path = tmp_path / "deck.pptx"
+    result = registry.call(
+        "mshtools-slides_generator",
+        content=html,
+        output_path=str(output_path),
+    )
+
+    assert result.success
+    data = result.data
+    assert data["path"] == str(output_path)
+    assert Path(data["path"]).is_file()
+
+    slides = data["slides"]
+    assert len(slides) == 2
+
+    assert slides[0] == {
+        "title": "Overview",
+        "bullets": ["First point", "Second point"],
+    }
+    assert slides[1] == {
+        "title": "Slide 2",
+        "bullets": ["Next steps", "Timeline"],
+    }


### PR DESCRIPTION
## Summary
- extract slide titles and bullet text when generating PPT decks
- return preview metadata alongside the PPT path so the UI can render slides
- add a regression test covering the new outline payload

## Testing
- pytest tests/test_tools_slides.py

------
https://chatgpt.com/codex/tasks/task_b_68e0e55c5b24832185723bb5f234352e