### PR TITLE
Refresh roadmap and developer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ Imagine seamlessly embedding a powerful, multi-modal agent brain into your own a
 .
 ├── spec/                # 📜 Canonical system prompt and tool specification files
 ├── src/okcvm/           # 🐍 Python source for the VM, tool registry, and reference tools
-├── frontend/            # 🎨 Assets and UI prototypes for OKCVM integrations
+├── frontend/            # 🎨 Static operator console served by the FastAPI backend
+├── docs/                # 🧭 In-depth architecture, backend, and frontend documentation
 ├── tests/               # 🧪 Automated test suite for validating tool and registry behavior
 ├── roadmap.md           # 🗺️ Project development roadmap (English)
 ├── roadmap.zh.md        # 🗺️ Project development roadmap (Chinese)
-└── README_PROJECT.md    # 📄 Additional background on project goals and architecture
+├── security.md          # 🔐 Security and hardening notes for deployments
+└── config.yaml          # ⚙️ Sample runtime configuration consumed by the CLI and API
 ```
 
 ## 🛠️ Getting Started
@@ -49,8 +51,8 @@ Get OKCVM up and running locally in just a few steps and experience its power.
 
 ```bash
 # Clone the repository and navigate into the directory
-git clone https://github.com/moonshot-ai/ok-computer-vm.git
-cd ok-computer-vm
+git clone https://github.com/kexinoh/free-OKC.git
+cd free-OKC
 
 # Create and activate a virtual environment (recommended)
 python -m venv venv
@@ -153,9 +155,9 @@ Once configured, you're ready to interact with the agent in the chat interface! 
 
 #### 5. Concurrency & Multi-User Access
 
-The demo FastAPI service keeps a single global `SessionState` instance in [`src/okcvm/api/main.py`](src/okcvm/api/main.py), so every browser tab shares the same conversation and workspace context. There is no automatic per-visitor isolation in this mode. [src/okcvm/api/main.py#L63-L69](src/okcvm/api/main.py#L63-L69)
+The FastAPI layer now provisions a dedicated `SessionState` per `client_id`. A stable identifier is stored in both cookies and `localStorage`, so each browser automatically receives an isolated workspace while multiple tabs from the same client remain in sync. [`src/okcvm/api/main.py`](src/okcvm/api/main.py) [`frontend/utils.js`](frontend/utils.js)
 
-To run multi-user or multi-session deployments, allocate a dedicated `SessionState` per user (for example by binding it to an authenticated account or an explicit session ID) and pass that instance into the relevant API routes.
+To integrate with your own identity system, resolve the authenticated account or session identifier on each request and pass it into the API via the `client_id` query parameter or the `x-okc-client-id` header. Sessions can also be pre-provisioned server side through [`SessionStore`](src/okcvm/api/main.py#L94-L149) if you need to share a workspace between collaborators.
 
 #### 6. Troubleshooting Tool Errors
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -32,11 +32,13 @@
 .
 ├── spec/                # 📜 系统指令和工具规范文件
 ├── src/okcvm/           # 🐍 虚拟机、工具注册表和工具实现的 Python 源代码
-├── frontend/            # 🎨 与 OKCVM 集成相关的前端资源和 UI 原型
+├── frontend/            # 🎨 由 FastAPI 托管的静态运维控制台
+├── docs/                # 🧭 架构、后端、前端等深入文档
 ├── tests/               # 🧪 用于验证工具和注册表行为的自动化测试套件
 ├── roadmap.md           # 🗺️ 项目发展路线图 (英文)
 ├── roadmap.zh.md        # 🗺️ 项目发展路线图 (中文)
-└── README_PROJECT.md    # 📄 关于项目目标和架构的更多背景信息
+├── security.md          # 🔐 部署安全与加固建议
+└── config.yaml          # ⚙️ CLI 与 API 可直接加载的示例运行配置
 ```
 
 ## 🛠️ 快速开始 (Getting Started)
@@ -47,7 +49,7 @@
 
 ```bash
 git clone https://github.com/kexinoh/free-OKC.git
-cd ok-computer-vm
+cd free-OKC
 
 python -m venv venv
 source venv/bin/activate  # macOS / Linux
@@ -145,9 +147,9 @@ okcvm-server
 
 #### 5. 并发与多用户访问 (Concurrency & Multi-User Access)
 
-当前的 FastAPI 服务在 `src/okcvm/api/main.py` 中维护了一个全局的 `SessionState` 单例，用于演示目的。也就是说，所有浏览器客户端都会共享同一个对话会话和工作空间，并不会为每位访客自动创建隔离上下文。 [src/okcvm/api/main.py#L63-L69](src/okcvm/api/main.py#L63-L69)
+FastAPI 层会按 `client_id` 创建独立的 `SessionState`。浏览器首次访问时会把该标识写入 cookie 与 `localStorage`，从而自动获得隔离的对话与工作区；同一客户端的多个标签页仍会共享状态。 [`src/okcvm/api/main.py`](src/okcvm/api/main.py) [`frontend/utils.js`](frontend/utils.js)
 
-如果需要支持真正的多用户或多会话并发，你需要在应用层为每位用户分配独立的 `SessionState` 实例（例如基于登录态或显式的会话 ID），并将它们注入到对应的 API 路由中。
+若要接入企业账号体系，可在每次请求时解析登录态并通过 `client_id` 查询参数或 `x-okc-client-id` 请求头传入。也可以使用 [`SessionStore`](src/okcvm/api/main.py#L94-L149) 预先分配共享会话，以便协作成员共同查看同一工作区。
 
 #### 6. 常见工具错误排查 (Troubleshooting Tool Errors)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,8 @@ together. If you are onboarding, start here before diving into the source tree.
 | File | Purpose |
 | ---- | ------- |
 | [`architecture.md`](./architecture.md) | System decomposition, runtime flow, and integration points between backend, frontend, and tooling. |
-| [`backend.md`](./backend.md) | Detailed explanation of configuration, LangChain orchestration, FastAPI routes, and supporting utilities. |
-| [`frontend.md`](./frontend.md) | Walkthrough of the static control panel, state management, accessibility patterns, and preview rendering. |
+| [`backend.md`](./backend.md) | Configuration loading, LangChain orchestration, FastAPI routes, and supporting utilities. |
+| [`frontend.md`](./frontend.md) | Module-by-module walkthrough of the static control panel, accessibility patterns, and preview rendering. |
 | [`workspace.md`](./workspace.md) | Deep dive into per-session sandboxes, Git snapshots, path resolution, and tool injection. |
 | [`session_tree.md`](./session_tree.md) | Conceptual model for how chat history, workspace commits, deployments, and artefacts form a navigable tree. |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,28 +16,31 @@ Python orchestrator, FastAPI API, and static operator console loosely coupled.
    and API surfaces. [src/okcvm/config.py#L25-L227](../src/okcvm/config.py#L25-L227) [src/okcvm/vm.py#L26-L178](../src/okcvm/vm.py#L26-L178)
 3. **HTTP API** – [`okcvm.api.main`](../src/okcvm/api/main.py) wraps FastAPI,
    serves static assets, implements authentication-free REST endpoints, and keeps
-   multi-client session state in-memory via `SessionStore`. [src/okcvm/api/main.py#L58-L309](../src/okcvm/api/main.py#L58-L309)
+   multi-client session state in-memory via `SessionStore` and a lightweight
+   `AppState` helper. [src/okcvm/api/main.py#L58-L309](../src/okcvm/api/main.py#L58-L309)
 4. **Control panel frontend** – Static assets in [`frontend/`](../frontend)
    deliver the dashboard experience with persistent conversations, settings
-   management, preview panes, and telemetry timelines. [frontend/index.html#L16-L220](../frontend/index.html#L16-L220) [frontend/app.js#L1-L851](../frontend/app.js#L1-L851)
+   management, preview panes, and telemetry timelines. [frontend/index.html#L16-L220](../frontend/index.html#L16-L220) [frontend/app.js#L1-L720](../frontend/app.js#L1-L720)
 
 ## Request lifecycle
 
 1. **Server startup** – The Typer CLI (`okcvm.server:cli`) loads layered
    configuration, validates the workspace directory, prepares logging, and spins
    up Uvicorn pointed at `okcvm.api.main:app`. [src/okcvm/server.py#L1-L88](../src/okcvm/server.py#L1-L88)
-2. **Session boot** – On the first API call, `SessionStore` provisions a new
-   `SessionState` which attaches a `WorkspaceManager`, loads the canonical prompt,
-   and instantiates a `VirtualMachine` bound to the default tool registry. [src/okcvm/api/main.py#L58-L209](../src/okcvm/api/main.py#L58-L209) [src/okcvm/session.py#L22-L90](../src/okcvm/session.py#L22-L90)
+2. **Session boot** – On the first API call, `SessionStore` provisions a
+   `SessionState` keyed by the caller’s `client_id`, attaches a `WorkspaceManager`,
+   loads the canonical prompt, and instantiates a `VirtualMachine` bound to the
+   default tool registry. [src/okcvm/api/main.py#L58-L209](../src/okcvm/api/main.py#L58-L209) [src/okcvm/session.py#L22-L90](../src/okcvm/session.py#L22-L90)
 3. **Chat execution** – The virtual machine adapts chat history into LangChain
    message objects, invokes the configured model, records tool calls, and returns
-   a structured payload consumed by the frontend. [src/okcvm/vm.py#L58-L178](../src/okcvm/vm.py#L58-L178)
+   a structured payload with normalised previews and artefacts consumed by the
+   frontend. [src/okcvm/vm.py#L58-L178](../src/okcvm/vm.py#L58-L178) [src/okcvm/session.py#L94-L279](../src/okcvm/session.py#L94-L279)
 4. **Workspace snapshotting** – After each response, the workspace state takes a
    Git snapshot and exposes metadata (latest commit, snapshot list, workspace
-   mount paths) via the session object so the UI can render the session tree. [src/okcvm/session.py#L94-L207](../src/okcvm/session.py#L94-L207) [src/okcvm/workspace.py#L32-L211](../src/okcvm/workspace.py#L32-L211)
+   mount paths) via the session object so the UI can render the session tree. [src/okcvm/session.py#L94-L369](../src/okcvm/session.py#L94-L369) [src/okcvm/workspace.py#L32-L211](../src/okcvm/workspace.py#L32-L211)
 5. **Frontend rendering** – The browser client fetches configuration and session
    info, renders conversation threads, writes HTML previews into an iframe, and
-   streams telemetry into the model log timeline. [frontend/app.js#L360-L851](../frontend/app.js#L360-L851)
+   streams telemetry into the model log timeline. [frontend/app.js#L260-L720](../frontend/app.js#L260-L720)
 
 ## Data boundaries and storage
 
@@ -49,9 +52,9 @@ Python orchestrator, FastAPI API, and static operator console loosely coupled.
   timelines. [src/okcvm/vm.py#L118-L178](../src/okcvm/vm.py#L118-L178)
 - **Workspace** – Each session receives a namespaced directory tree, optionally
   Git-backed, to isolate file operations and persist artefacts between requests. [src/okcvm/workspace.py#L32-L211](../src/okcvm/workspace.py#L32-L211)
-- **Frontend cache** – `localStorage` holds conversation metadata for quick
-  restoration after reloads; the backend remains stateless beyond workspace
-  directories. [frontend/app.js#L1-L360](../frontend/app.js#L1-L360)
+- **Frontend cache** – `localStorage` holds conversation metadata and the
+  generated `client_id` for quick restoration after reloads; the backend remains
+  stateless beyond workspace directories. [frontend/utils.js#L1-L120](../frontend/utils.js#L1-L120) [frontend/conversationState.js#L1-L240](../frontend/conversationState.js#L1-L240)
 
 ## Testing and observability
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -5,60 +5,77 @@ bundle by FastAPI. It focuses on clarity, offline readiness, and presenting agen
 activity in a way that supports rapid iteration.
 
 ## Layout and accessibility
-- [`index.html`](../frontend/index.html) defines a three-pane layout consisting of
-  a history sidebar, chat workspace, and insight column with web/PPT previews.
-  Landmark roles and ARIA attributes ensure the panel stays keyboard navigable,
-  including focus management for dialogs and interactive lists. [frontend/index.html#L16-L220](../frontend/index.html#L16-L220)
-- The settings overlay is implemented as an accessible dialog with labelled
-  controls for configuring chat, image, speech, sound-effects, and ASR endpoints.
-  The drawer toggles via the gear button, traps focus while open, and restores
-  focus when dismissed. [frontend/index.html#L119-L220](../frontend/index.html#L119-L220)
+- [`index.html`](../frontend/index.html) defines the workspace header, chat
+  surface, insight column, and history sidebar using landmark roles, labelled
+  controls, and focus traps so the console remains keyboard accessible. [frontend/index.html#L16-L220](../frontend/index.html#L16-L220)
+- [`styles.css`](../frontend/styles.css) implements the responsive shell,
+  high-contrast colour system, and focus outlines for dialogs, drawers, and the
+  preview pane. Utility custom properties (`--history-offset`, `--history-height`)
+  are toggled by the runtime to keep the layout stable during resizes. [frontend/styles.css#L1-L200](../frontend/styles.css#L1-L200)
+- [`elements.js`](../frontend/elements.js) centralises DOM lookups so other
+  modules can depend on semantic IDs instead of querying the document directly,
+  reducing the risk of stale selectors. [frontend/elements.js#L1-L120](../frontend/elements.js#L1-L120)
 
-## State management
-- [`app.js`](../frontend/app.js) initialises DOM references, memoises them in a
-  `ui` registry, and coordinates rendering via pure functions rather than heavy
-  frameworks. Conversation state is persisted to `localStorage` using the
-  `storage` helper, allowing tab reloads to restore context instantly. [frontend/app.js#L1-L360](../frontend/app.js#L1-L360)
-- The `state` object tracks conversations, active session IDs, pending messages,
-  preview metadata, and configuration status. Mutations go through dedicated
-  reducers (`upsertConversation`, `setActiveConversation`, etc.) so the rendering
-  layer can remain predictable. [frontend/app.js#L360-L620](../frontend/app.js#L360-L620)
+## Application composition
+- [`app.js`](../frontend/app.js) orchestrates event wiring: it loads stored
+  conversations, initialises preview controls, binds history layout observers,
+  and delegates actions (send, regenerate, branch, open editor) to specialised
+  helpers. [frontend/app.js#L1-L260](../frontend/app.js#L1-L260)
+- The module imports focused utilities for rendering (`previews.js`),
+  conversation state (`conversationState.js`), configuration (`config.js`), and
+  editing (`editor.js`), keeping the main file a coordinator rather than a data
+  store. [frontend/app.js#L21-L80](../frontend/app.js#L21-L80)
+- UI state (active conversation, pending messages, history layout measurements)
+  is tracked through pure functions so rerenders remain predictable and
+  testable. [frontend/app.js#L262-L720](../frontend/app.js#L262-L720)
 
-## Rendering pipeline
-- Conversations render as grouped bubbles with optimistic assistant placeholders.
-  When `/api/chat` resolves, the placeholder is replaced with the final response,
-  previews are refreshed, and the conversation list reorders to keep the most
-  recent threads on top. [frontend/app.js#L624-L851](../frontend/app.js#L624-L851)
-- Web previews write HTML into an iframe using `srcdoc`, while slide decks map
-  over returned PPT metadata to render cards and a modal carousel. The UI guards
-  against stale previews by clearing frames whenever the active conversation
-  changes. [frontend/app.js#L624-L789](../frontend/app.js#L624-L789)
+## Conversation state and branching
+- [`conversationState.js`](../frontend/conversationState.js) owns the in-memory
+  model: it persists conversations, message branches, and selection indices,
+  generates stable IDs, and keeps storage snapshots in sync. [frontend/conversationState.js#L1-L260](../frontend/conversationState.js#L1-L260)
+- Branch management utilities (`ensureBranchBaseline`, `commitBranchTransition`,
+  `captureBranchSelections`) capture before/after snapshots so users can explore
+  alternative replies without losing history. [frontend/conversationState.js#L60-L200](../frontend/conversationState.js#L60-L200)
+- [`storage.js`](../frontend/storage.js) guards `localStorage` access, falling
+  back gracefully when the environment disallows persistence. [frontend/storage.js#L1-L36](../frontend/storage.js#L1-L36)
 
-## Networking and error handling
-- `fetchJson` centralises HTTP requests with timeout handling, descriptive error
-  messages, and automatic JSON parsing. It powers configuration, session boot,
-  chat submission, snapshot management, and deployment asset lookups. [frontend/app.js#L689-L851](../frontend/app.js#L689-L851)
-- Form helpers (`populateConfigForm`, `submitConfigForm`) sync backend
-  descriptions into the drawer, handle optimistic UI states, and surface toast
-  notifications upon success or failure. [frontend/app.js#L689-L789](../frontend/app.js#L689-L789)
+## Networking and client identity
+- [`utils.js`](../frontend/utils.js) issues authenticated requests: `fetchJson`
+  injects the caller’s `client_id` into headers and URLs, handles JSON parsing,
+  and normalises errors for user-friendly toasts. [frontend/utils.js#L1-L120](../frontend/utils.js#L1-L120)
+- The helper also generates and stores `client_id` values, syncing cookies and
+  `localStorage` so multiple tabs share the same backend session. [frontend/utils.js#L30-L90](../frontend/utils.js#L30-L90)
+- [`config.js`](../frontend/config.js) builds on these utilities to populate and
+  submit the model configuration drawer, redacting API keys after each save. [frontend/config.js#L1-L110](../frontend/config.js#L1-L110)
 
-## Telemetry and logging
-- `logModelInvocation` captures the meta telemetry returned by `/api/chat`,
-  capping the timeline to six entries, showing token usage, tool invocations, and
-  latency summaries. The empty state is kept in sync when conversations reset. [frontend/app.js#L598-L677](../frontend/app.js#L598-L677)
-- A debug console is rendered conditionally when `localStorage.debug` is set,
-  echoing raw payloads to help diagnose integration issues without opening the
-  browser inspector. [frontend/app.js#L552-L620](../frontend/app.js#L552-L620)
+## Previews and telemetry
+- [`previews.js`](../frontend/previews.js) renders web iframes, slide decks, and
+  the model log timeline. It normalises backend payloads, manages sandbox modes,
+  and caps telemetry history for readability. [frontend/previews.js#L1-L200](../frontend/previews.js#L1-L200)
+- Preview controls expose actions such as opening deployments in a new tab or
+  toggling slide carousel mode, keeping the insight column interactive without
+  coupling it to chat rendering. [frontend/previews.js#L200-L360](../frontend/previews.js#L200-L360)
+
+## Configuration and message editing
+- [`config.js`](../frontend/config.js) pairs service-specific inputs with status
+  messaging so operators know when credentials were loaded, saved, or require
+  re-entry. [frontend/config.js#L14-L110](../frontend/config.js#L14-L110)
+- [`editor.js`](../frontend/editor.js) wraps the Toast UI Markdown editor in an
+  accessible dialog, handling focus management, keyboard shortcuts, and async
+  resolution so chat regeneration can reuse user-edited prompts. [frontend/editor.js#L1-L160](../frontend/editor.js#L1-L160)
+- [`messageActionIcons.js`](../frontend/messageActionIcons.js) and
+  [`markdown.js`](../frontend/markdown.js) encapsulate button cloning and secure
+  markdown rendering, reducing duplication when extending the chat UI. [frontend/messageActionIcons.js#L1-L120](../frontend/messageActionIcons.js#L1-L120) [frontend/markdown.js#L1-L160](../frontend/markdown.js#L1-L160)
 
 ## Extending the UI
 
-When adding new backend capabilities:
+When adding new frontend capabilities:
 
-1. Update the `state` shape and provide dedicated render/update helpers rather
-   than mutating DOM nodes inline.
-2. Keep network access wrapped in `fetchJson` so error handling stays
-   consistent.
-3. Reflect new previews in both the main insight pane and the history list to
-   maintain spatial awareness for operators.
-4. Update documentation and alt text to keep the console accessible across
-   screen readers and localisation contexts.
+1. Update `conversationState.js` (and its storage schema) alongside any new
+   state shape to keep persistence deterministic.
+2. Route network requests through `fetchJson` so client identifiers and error
+   handling stay consistent.
+3. Extend `previews.js` when introducing new artefact types; prefer injecting
+   metadata via the backend rather than parsing DOM content.
+4. Keep accessibility guards in sync—update `elements.js`, ARIA labels in
+   `index.html`, and focus logic in `app.js`/`editor.js` as new controls appear.


### PR DESCRIPTION
## Summary
- update README files to reflect the current repository layout and client-scoped session handling
- revise both roadmaps with notes on artifact normalisation, per-client sessions, and the modular frontend
- refresh architecture, backend, frontend, and session tree docs to document the new module boundaries and request flow

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68e0e93545788321a0b0267d1dd745d4