### PR TITLE
Add streaming chat support with tool status UI

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -517,6 +517,71 @@ body.no-scroll { overflow: hidden; }
 .message .message-content.pending {
   color: var(--text-secondary);
 }
+
+.message .streaming-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.message .streaming-text {
+  white-space: pre-wrap;
+  line-height: 1.65;
+}
+
+.message .tool-status-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.message .tool-status-container:empty {
+  display: none;
+}
+
+.message .tool-status-card {
+  border: 1px solid var(--border-color);
+  border-radius: 0.9rem;
+  padding: 0.75rem 0.9rem;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+
+.message.assistant .tool-status-card {
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.message .tool-status-card.completed {
+  border-color: var(--accent-color);
+}
+
+.message .tool-status-card.error {
+  border-color: #d94848;
+  background: rgba(217, 72, 72, 0.08);
+}
+
+.message .tool-status-title {
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.35rem;
+}
+
+.message .tool-status-card pre.tool-status-details {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.message .tool-status-summary {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
 .message-footer {
   display: flex;
   align-items: center;

--- a/src/okcvm/api/models.py
+++ b/src/okcvm/api/models.py
@@ -45,6 +45,13 @@ class ChatRequest(BaseModel):
             "conversation turns."
         ),
     )
+    stream: bool = Field(
+        default=True,
+        description=(
+            "When true the response is delivered as a server-sent event stream with "
+            "incremental updates."
+        ),
+    )
 
 
 class SnapshotCreatePayload(BaseModel):

--- a/src/okcvm/llm.py
+++ b/src/okcvm/llm.py
@@ -30,7 +30,7 @@ def create_llm_chain(registry: ToolRegistry):
         api_key=chat_config.api_key,
         base_url=chat_config.base_url,
         temperature=0.7,
-        streaming=False,  # 对于工具调用，非流式更简单
+        streaming=True,
     )
 
     # 3. 将我们的工具绑定到模型上

--- a/src/okcvm/streaming.py
+++ b/src/okcvm/streaming.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any, AsyncIterator, Callable, Dict, Optional
+from uuid import UUID
+
+from langchain_core.callbacks.base import BaseCallbackHandler
+
+
+def _normalise_text(value: Any) -> Optional[str]:
+    """Return a readable string representation for tool payloads."""
+
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        text = str(value)
+        return text.strip() or None
+
+
+def _truncate(text: str, limit: int = 320) -> str:
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 1]}…"
+
+
+class EventStreamPublisher:
+    """Thread-safe helper that serialises events into SSE payloads."""
+
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+        self._queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+        self._closed = False
+
+    def publish(self, event: Dict[str, Any]) -> None:
+        """Schedule *event* to be emitted to connected clients."""
+
+        if self._closed:
+            return
+
+        def _enqueue() -> None:
+            if not self._closed:
+                self._queue.put_nowait(event)
+
+        self._loop.call_soon_threadsafe(_enqueue)
+
+    def close(self) -> None:
+        self._closed = True
+
+    async def iter_sse(self) -> AsyncIterator[bytes]:
+        """Yield server-sent event payloads until a terminal message is sent."""
+
+        try:
+            while True:
+                event = await self._queue.get()
+                payload = json.dumps(event, ensure_ascii=False)
+                yield f"data: {payload}\n\n".encode("utf-8")
+                if event.get("type") in {"final", "error"}:
+                    break
+        finally:
+            self._closed = True
+
+
+class LangChainStreamingHandler(BaseCallbackHandler):
+    """Relay LangChain runtime events to the front-end via SSE."""
+
+    def __init__(self, publish: Callable[[Dict[str, Any]], None]) -> None:
+        super().__init__()
+        self._publish = publish
+        self._tool_start_times: Dict[UUID, float] = {}
+        self._tool_names: Dict[UUID, str] = {}
+
+    def on_llm_new_token(self, token: str, **kwargs: Any) -> None:  # noqa: ANN401
+        if token:
+            self._publish({"type": "token", "delta": token})
+
+    def on_tool_start(
+        self,
+        serialized: Dict[str, Any],  # noqa: ANN401
+        input_str: str,
+        run_id: UUID,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> None:
+        name = None
+        if isinstance(serialized, dict):
+            name = serialized.get("name") or serialized.get("id")
+        details = _normalise_text(input_str)
+        event: Dict[str, Any] = {
+            "type": "tool_started",
+            "invocation_id": str(run_id),
+        }
+        if name:
+            event["tool_name"] = name
+            self._tool_names[run_id] = name
+        if details:
+            event["input"] = _truncate(details)
+        self._tool_start_times[run_id] = time.perf_counter()
+        self._publish(event)
+
+    def on_tool_end(
+        self,
+        output: Any,
+        run_id: UUID,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> None:
+        preview = _normalise_text(output)
+        elapsed_ms = None
+        started = self._tool_start_times.pop(run_id, None)
+        if started is not None:
+            elapsed_ms = (time.perf_counter() - started) * 1000
+        tool_name = self._tool_names.pop(run_id, None)
+        event: Dict[str, Any] = {
+            "type": "tool_completed",
+            "invocation_id": str(run_id),
+            "status": "success",
+        }
+        if tool_name:
+            event["tool_name"] = tool_name
+        if elapsed_ms is not None:
+            event["duration_ms"] = round(elapsed_ms, 2)
+        if preview:
+            event["output"] = _truncate(preview)
+        self._publish(event)
+
+    def on_tool_error(
+        self,
+        error: Exception,
+        run_id: UUID,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> None:
+        started = self._tool_start_times.pop(run_id, None)
+        elapsed_ms = None
+        if started is not None:
+            elapsed_ms = (time.perf_counter() - started) * 1000
+        message = str(error).strip() or "Tool execution failed"
+        tool_name = self._tool_names.pop(run_id, None)
+        event: Dict[str, Any] = {
+            "type": "tool_completed",
+            "invocation_id": str(run_id),
+            "status": "error",
+            "error": message,
+        }
+        if tool_name:
+            event["tool_name"] = tool_name
+        if elapsed_ms is not None:
+            event["duration_ms"] = round(elapsed_ms, 2)
+        self._publish(event)
+
+
+__all__ = ["EventStreamPublisher", "LangChainStreamingHandler"]

--- a/tests/test_api_flows.py
+++ b/tests/test_api_flows.py
@@ -56,7 +56,7 @@ class _StubVirtualMachine:
         self._counter += 1
         return f"stub-{self._counter:04d}"
 
-    def execute(self, message: str) -> Dict[str, object]:
+    def execute(self, message: str, **kwargs) -> Dict[str, object]:  # noqa: ANN001
         user_entry = {"role": "user", "content": message, "id": self._next_id()}
         reply_text = f"Stub response: {message}"
         assistant_entry = {
@@ -132,7 +132,7 @@ def test_session_flow_boot_chat_history_and_cleanup(client):
 
     chat_response = client.post(
         "/api/chat",
-        json={"message": "生成一个静态网页", "replace_last": False},
+        json={"message": "生成一个静态网页", "replace_last": False, "stream": False},
     )
     assert chat_response.status_code == 200
     chat_payload = chat_response.json()
@@ -169,7 +169,7 @@ def test_session_flow_supports_replace_last_via_api(client):
 
     first = client.post(
         "/api/chat",
-        json={"message": "第一次回复", "replace_last": False},
+        json={"message": "第一次回复", "replace_last": False, "stream": False},
     )
     assert first.status_code == 200
     first_history = first.json()["vm_history"]
@@ -177,7 +177,7 @@ def test_session_flow_supports_replace_last_via_api(client):
 
     regen = client.post(
         "/api/chat",
-        json={"message": "重新生成第二次", "replace_last": True},
+        json={"message": "重新生成第二次", "replace_last": True, "stream": False},
     )
     assert regen.status_code == 200
     regen_payload = regen.json()

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -88,7 +88,7 @@ def test_create_llm_chain_uses_config(monkeypatch):
         "api_key": "sk-sim",
         "base_url": "https://chat.sim",
         "temperature": 0.7,
-        "streaming": False,
+        "streaming": True,
     }
     assert len(captured["bound_tools"][1]) == 2
     assert captured["executor_verbose"] is True

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -14,7 +14,7 @@ class DummyVM:
         self.history: list[Dict[str, Any]] = []
         self._response: Dict[str, Any] = {"reply": "", "tool_calls": []}
 
-    def execute(self, message: str) -> Dict[str, Any]:
+    def execute(self, message: str, **kwargs: Any) -> Dict[str, Any]:
         self.history.append({"role": "user", "content": message})
         reply = self._response.get("reply", "")
         self.history.append({"role": "assistant", "content": reply})
@@ -110,7 +110,7 @@ def test_session_collects_preview_without_intermediate_steps(tmp_path, monkeypat
         def __init__(self, registry):
             self.registry = registry
 
-        def invoke(self, inputs):
+        def invoke(self, inputs, config=None):  # noqa: ANN001
             workspace = self.registry.workspace
             site_root = workspace.resolve("site")
             site_root.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- add a streaming callback handler and SSE publisher to surface incremental chat events
- wire the VM, session layer, and FastAPI endpoint to default to streaming responses
- update the frontend to consume streamed tokens, render tool status cards, and add streaming utilities and styles
- adjust request models and tests for the new streaming behaviour

## Testing
- pytest tests/test_llm.py tests/test_session.py tests/test_api_app.py tests/test_api_flows.py

------
https://chatgpt.com/codex/tasks/task_b_68e123f457208321a286dba6d4f72536