### PR TITLE
Add configuration flag for streaming support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,8 @@ chat:
   model: "kimi-k2-0905-preview"
   base_url: "https://api.moonshot.cn/v1"
   api_key: "-----"
+  # Set to false if the upstream provider does not support SSE streaming.
+  supports_streaming: true
 
 # Media generation models are optional.
 # If you don't need a specific tool, you can comment it out or remove it.

--- a/src/okcvm/api/main.py
+++ b/src/okcvm/api/main.py
@@ -396,6 +396,12 @@ def create_app() -> FastAPI:
                         and config.chat is not None
                     ):
                         chat_config.api_key = config.chat.api_key
+                    if (
+                        "supports_streaming" not in payload.chat.model_fields_set
+                        and config.chat is not None
+                        and config.chat.supports_streaming is not None
+                    ):
+                        chat_config.supports_streaming = config.chat.supports_streaming
                     configure_kwargs["chat"] = chat_config
 
         media_fields = ("image", "speech", "sound_effects", "asr")
@@ -424,6 +430,11 @@ def create_app() -> FastAPI:
                     and current_value is not None
                 ):
                     endpoint_config.api_key = current_value.api_key
+                if (
+                    "supports_streaming" not in endpoint_payload.model_fields_set
+                    and current_value is not None
+                ):
+                    endpoint_config.supports_streaming = current_value.supports_streaming
                 return endpoint_config
 
             media_config = MediaConfig(
@@ -493,7 +504,17 @@ def create_app() -> FastAPI:
             payload.replace_last,
             payload.message[:120],
         )
-        if payload.stream:
+        streaming_requested = payload.stream
+        if streaming_requested:
+            chat_config = config.chat if (config := get_config()) else None
+            if chat_config is None or not chat_config.supports_streaming:
+                logger.warning(
+                    "Streaming requested but disabled (configured=%s)",
+                    chat_config is not None,
+                )
+                streaming_requested = False
+
+        if streaming_requested:
             loop = asyncio.get_running_loop()
             publisher = EventStreamPublisher(loop)
 

--- a/src/okcvm/api/main.py
+++ b/src/okcvm/api/main.py
@@ -506,7 +506,7 @@ def create_app() -> FastAPI:
         )
         streaming_requested = payload.stream
         if streaming_requested:
-            chat_config = config.chat if (config := get_config()) else None
+            chat_config = get_config().chat
             if chat_config is None or not chat_config.supports_streaming:
                 logger.warning(
                     "Streaming requested but disabled (configured=%s)",

--- a/src/okcvm/api/models.py
+++ b/src/okcvm/api/models.py
@@ -13,6 +13,10 @@ class EndpointConfigPayload(BaseModel):
     model: Optional[str] = Field(default=None, description="Model identifier")
     base_url: Optional[str] = Field(default=None, description="Endpoint base URL")
     api_key: Optional[str] = Field(default=None, description="Provider API key")
+    supports_streaming: Optional[bool] = Field(
+        default=None,
+        description="Whether the endpoint supports server-sent event streaming.",
+    )
 
     def to_model(self) -> ModelEndpointConfig | None:
         model = self.model.strip() if self.model is not None else None
@@ -20,7 +24,14 @@ class EndpointConfigPayload(BaseModel):
         api_key = self.api_key.strip() if self.api_key is not None else None
         if not model or not base_url:
             return None
-        return ModelEndpointConfig(model=model, base_url=base_url, api_key=api_key or None)
+        return ModelEndpointConfig(
+            model=model,
+            base_url=base_url,
+            api_key=api_key or None,
+            supports_streaming=self.supports_streaming
+            if self.supports_streaming is not None
+            else True,
+        )
 
 
 class ConfigUpdatePayload(BaseModel):

--- a/src/okcvm/config.py
+++ b/src/okcvm/config.py
@@ -29,7 +29,7 @@ from .logging_utils import get_logger
 
 logger = get_logger(__name__)
 
-def _parse_bool(value: object, *, default: bool = False) -> bool:
+def _parse_bool(value: object, *, default: bool = True) -> bool:
     """Parse ``value`` into a boolean flag."""
 
     if isinstance(value, bool):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,9 +33,19 @@ def test_model_endpoint_config_from_env_with_partial_values():
     assert cfg.model == "stable-pixel"
     assert cfg.base_url == "https://image.api"
     assert cfg.api_key is None
+    assert cfg.supports_streaming is True
 
     missing = ModelEndpointConfig.from_env("OKCVM_SPEECH", env)
     assert missing is None
+
+    env_with_flag = {
+        "OKCVM_IMAGE_MODEL": "stable-pixel",
+        "OKCVM_IMAGE_BASE_URL": "https://image.api",
+        "OKCVM_IMAGE_SUPPORTS_STREAMING": "false",
+    }
+    cfg_flag = ModelEndpointConfig.from_env("OKCVM_IMAGE", env_with_flag)
+    assert cfg_flag is not None
+    assert cfg_flag.supports_streaming is False
 
 
 def test_model_endpoint_config_describe_hides_api_key():
@@ -49,6 +59,7 @@ def test_model_endpoint_config_describe_hides_api_key():
         "model": "speech-pro",
         "base_url": "https://speech.api",
         "api_key_present": True,
+        "supports_streaming": True,
     }
 
 
@@ -94,12 +105,14 @@ def test_load_config_from_yaml_supports_env_keys(tmp_path: Path, monkeypatch):
             "model": "gpt-yaml",
             "base_url": "https://chat.yaml",
             "api_key_env": "CHAT_API_KEY",
+            "supports_streaming": False,
         },
         "media": {
             "image": {
                 "model": "image-yaml",
                 "base_url": "https://image.yaml",
                 "api_key": "inline-image",
+                "supports_streaming": False,
             },
             "speech": {
                 "model": "speech-yaml",
@@ -117,8 +130,10 @@ def test_load_config_from_yaml_supports_env_keys(tmp_path: Path, monkeypatch):
 
     assert cfg.chat is not None
     assert cfg.chat.api_key == "sk-chat"
+    assert cfg.chat.supports_streaming is False
     assert cfg.media.image is not None
     assert cfg.media.image.api_key == "inline-image"
+    assert cfg.media.image.supports_streaming is False
     assert cfg.media.speech is not None
     assert cfg.media.speech.api_key == "sk-speech"
     assert cfg.workspace.preview_base_url is None

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -41,6 +41,7 @@ def test_generate_image_and_audio():
         "model": "stub-model",
         "base_url": "https://example.invalid/v1",
         "api_key_present": True,
+        "supports_streaming": True,
     }
 
     voices = registry.call("mshtools-get_available_voices")
@@ -54,6 +55,7 @@ def test_generate_image_and_audio():
         "model": "stub-model",
         "base_url": "https://example.invalid/v1",
         "api_key_present": True,
+        "supports_streaming": True,
     }
 
     effect = registry.call("mshtools-generate_sound_effects", description="gentle rain", duration=1.0)
@@ -64,4 +66,5 @@ def test_generate_image_and_audio():
         "model": "stub-model",
         "base_url": "https://example.invalid/v1",
         "api_key_present": True,
+        "supports_streaming": True,
     }


### PR DESCRIPTION
## Summary
- add a `supports_streaming` flag to model endpoint configuration and surface it through the API and CLI
- fall back to non-streaming chat responses when the configured endpoint disables streaming
- extend configuration tests and fixtures to cover the new capability

## Testing
- pytest tests/test_config.py tests/test_media.py tests/test_api_app.py

------
https://chatgpt.com/codex/tasks/task_b_68e1380c5770832191927773ae79d93e