### PR TITLE
Add inline chat editing and ctrl+enter send

### DIFF
--- a/frontend/app/historyLayout.js
+++ b/frontend/app/historyLayout.js
@@ -1,11 +1,14 @@
-function resolveChatPanel(chatPanel, chatMessages) {
+function resolveLayoutTarget(layoutTarget, chatPanel, chatMessages) {
+  if (layoutTarget instanceof HTMLElement) {
+    return layoutTarget;
+  }
   if (chatPanel instanceof HTMLElement) {
     return chatPanel;
   }
   return chatMessages?.closest?.('.chat-panel') ?? null;
 }
 
-export function createHistoryLayoutManager({ historySidebar, chatPanel, chatMessages }) {
+export function createHistoryLayoutManager({ historySidebar, layoutTarget, chatPanel, chatMessages }) {
   if (!(historySidebar instanceof HTMLElement)) {
     return {
       requestLayoutSync: () => {},
@@ -18,17 +21,17 @@ export function createHistoryLayoutManager({ historySidebar, chatPanel, chatMess
   let resizeObserver = null;
 
   const applyMeasurements = () => {
-    const targetChatPanel = resolveChatPanel(chatPanel, chatMessages);
-    if (!(targetChatPanel instanceof HTMLElement)) {
+    const target = resolveLayoutTarget(layoutTarget, chatPanel, chatMessages);
+    if (!(target instanceof HTMLElement)) {
       historySidebar.style.removeProperty('--history-offset');
       historySidebar.style.removeProperty('--history-height');
       return;
     }
 
     const sidebarRect = historySidebar.getBoundingClientRect();
-    const chatRect = targetChatPanel.getBoundingClientRect();
-    const offset = Math.max(chatRect.top - sidebarRect.top, 0);
-    const height = chatRect.height;
+    const targetRect = target.getBoundingClientRect();
+    const offset = Math.max(targetRect.top - sidebarRect.top, 0);
+    const height = targetRect.height;
 
     if (!Number.isFinite(offset) || !Number.isFinite(height) || height <= 0) {
       historySidebar.style.removeProperty('--history-offset');

--- a/frontend/app/messageRenderer.js
+++ b/frontend/app/messageRenderer.js
@@ -279,7 +279,7 @@ export function createMessageRenderer({
     const target = conversation ?? getCurrentConversation();
 
     if (editingController.isEditing()) {
-      editingController.cancelActiveEdit({ focusInput: false });
+      editingController.cancelActiveEdit({ focusInput: false, focusEditButton: false });
     }
 
     if (!target) {

--- a/frontend/elements.js
+++ b/frontend/elements.js
@@ -1,8 +1,8 @@
 export const chatMessages = document.getElementById('chat-messages');
 export const chatForm = document.getElementById('chat-form');
 export const userInput = document.getElementById('user-input');
-export const cancelEditButton = document.getElementById('cancel-edit');
 export const chatEditingHint = document.getElementById('chat-editing-hint');
+export const appShell = document.querySelector('.app-shell');
 export const chatPanel = document.querySelector('.chat-panel');
 export const statusPill = document.getElementById('status-pill');
 export const modelLogList = document.getElementById('model-log');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -75,18 +75,10 @@
                 required
               ></textarea>
               <p class="chat-input-hint" id="chat-editing-hint" hidden>
-                正在编辑历史消息，点击“保存”完成修改。
+                正在编辑历史消息，点击“发送”完成修改。
               </p>
             </div>
             <div class="chat-input-actions">
-              <button
-                type="button"
-                class="ghost-button cancel-edit-button"
-                id="cancel-edit"
-                hidden
-              >
-                取消编辑
-              </button>
               <button type="submit" class="send-button">发送</button>
             </div>
           </form>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -518,6 +518,58 @@ body.no-scroll { overflow: hidden; }
   color: var(--text-secondary);
 }
 
+.message.editing {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-soft);
+}
+
+.message.editing .branch-navigation {
+  visibility: hidden;
+}
+
+.message.editing .message-actions {
+  display: none;
+}
+
+.message-edit-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.message-edit-textarea {
+  width: 100%;
+  min-height: 6.5rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--border-color);
+  background: #ffffff;
+  padding: 0.85rem 1rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--text-primary);
+  resize: vertical;
+  box-shadow: inset 0 1px 2px rgba(15, 15, 15, 0.06);
+}
+
+.message-edit-textarea:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+}
+
+.message-edit-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+.message-edit-actions .ghost-button,
+.message-edit-actions .primary-button {
+  min-width: 5.5rem;
+}
+
 .message .streaming-content {
   display: flex;
   flex-direction: column;
@@ -726,10 +778,6 @@ body.no-scroll { overflow: hidden; }
   box-shadow: none;
 }
 
-.chat-input.editing textarea {
-  background: rgba(0, 0, 0, 0.02);
-}
-
 .chat-input textarea:focus {
   outline: none;
 }
@@ -752,15 +800,6 @@ body.no-scroll { overflow: hidden; }
   color: var(--text-secondary);
 }
 
-.chat-input.editing .send-button {
-  background: var(--accent-strong);
-}
-
-.cancel-edit-button {
-  padding: 0.55rem 1rem;
-  border-radius: 0.75rem;
-  font-weight: 500;
-}
 .send-button {
   border-radius: 0.85rem;
   font-size: 0.95rem;
@@ -1002,7 +1041,6 @@ body.no-scroll { overflow: hidden; }
   .chat-input-actions {
     flex-direction: row;
   }
-  .cancel-edit-button,
   .send-button {
     width: 100%;
   }


### PR DESCRIPTION
## Summary
- allow users to submit messages with Ctrl+Enter and mirror the shortcut inside the inline editor
- move the edit flow into each chat bubble with inline cancel/send controls and refreshed styles
- align the history sidebar with the full app shell height for top/bottom consistency and remove the old footer cancel button

## Testing
- No automated tests were run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_b_68e14d3e21408321ae5e3546049c9416