### PR TITLE
Refine chat editing experience and history layout

### DIFF
--- a/frontend/app/editingController.js
+++ b/frontend/app/editingController.js
@@ -16,6 +16,7 @@ export function createEditingController({
   commitBranchTransition,
   syncActiveBranchSnapshots,
   saveConversationsToStorage,
+  setMessageActionsDisabled,
 }) {
   let activeEditState = null;
 
@@ -30,97 +31,116 @@ export function createEditingController({
     }
   };
 
-  const resetEditingUi = ({ focusInput = false, clearInput = true } = {}) => {
-    activeEditState = null;
-
+  const restoreLegacyFormState = () => {
     if (chatForm) {
       chatForm.classList.remove('editing');
       delete chatForm.dataset.editing;
     }
-
     if (sendButton) {
       sendButton.textContent = defaultSendButtonLabel;
+      sendButton.disabled = false;
     }
-
     if (cancelEditButton) {
       cancelEditButton.hidden = true;
       cancelEditButton.disabled = false;
     }
-
     if (chatEditingHint) {
       chatEditingHint.hidden = true;
       if (defaultEditingHintText) {
         chatEditingHint.textContent = defaultEditingHintText;
       }
     }
-
     if (userInput) {
-      if (clearInput) {
-        userInput.value = '';
-      }
       userInput.placeholder = defaultInputPlaceholder;
-      if (focusInput) {
+      userInput.disabled = false;
+    }
+  };
+
+  restoreLegacyFormState();
+
+  const teardownInlineEditor = ({ focusInput = false, restoreFocus } = {}) => {
+    if (!activeEditState) {
+      restoreLegacyFormState();
+      if (restoreFocus instanceof HTMLElement) {
+        restoreFocus.focus();
+      } else if (focusInput) {
         focusInputEnd();
       }
+      return;
+    }
+
+    const {
+      messageElement,
+      editorForm,
+      messageBody,
+      messageFooter,
+      bodyWasHidden,
+      footerWasHidden,
+      triggerButton,
+    } = activeEditState;
+
+    if (messageBody instanceof HTMLElement) {
+      messageBody.hidden = bodyWasHidden;
+    }
+    if (messageFooter instanceof HTMLElement) {
+      messageFooter.hidden = footerWasHidden;
+    }
+
+    if (editorForm instanceof HTMLElement && editorForm.isConnected) {
+      editorForm.remove();
+    }
+
+    if (messageElement instanceof HTMLElement) {
+      messageElement.classList.remove('editing');
+      if (messageElement.dataset) {
+        delete messageElement.dataset.editing;
+      }
+    }
+
+    if (typeof setMessageActionsDisabled === 'function' && messageElement instanceof HTMLElement) {
+      setMessageActionsDisabled(messageElement, false);
+    }
+
+    const shouldRestoreTrigger =
+      !focusInput &&
+      triggerButton instanceof HTMLElement &&
+      typeof document !== 'undefined' &&
+      document.contains(triggerButton);
+
+    activeEditState = null;
+
+    restoreLegacyFormState();
+
+    if (focusInput) {
+      focusInputEnd();
+    } else if (restoreFocus instanceof HTMLElement) {
+      restoreFocus.focus();
+    } else if (shouldRestoreTrigger) {
+      triggerButton.focus();
     }
   };
 
   const isEditing = () => activeEditState !== null;
 
-  const cancelActiveEdit = (options = {}) => {
-    resetEditingUi(options);
-  };
+  function cancelActiveEdit(options = {}) {
+    teardownInlineEditor(options);
+  }
 
-  const enterEditModeForMessage = ({
-    conversation,
-    message,
-    initialValue,
-    previousMessages,
-    previousSelections,
-  }) => {
-    if (!conversation || !message || !chatForm || !userInput) {
-      return;
-    }
-
-    activeEditState = {
-      conversationId: conversation.id,
-      messageId: message.id,
-      previousMessages,
-      previousSelections,
-    };
-
-    chatForm.dataset.editing = 'true';
-    chatForm.classList.add('editing');
-
-    if (sendButton) {
-      sendButton.textContent = '保存';
-    }
-
-    if (cancelEditButton) {
-      cancelEditButton.hidden = false;
-      cancelEditButton.disabled = false;
-    }
-
-    if (chatEditingHint) {
-      if (defaultEditingHintText) {
-        chatEditingHint.textContent = defaultEditingHintText;
-      }
-      chatEditingHint.hidden = false;
-    }
-
-    const value = typeof initialValue === 'string' ? initialValue : '';
-    userInput.value = value;
-    userInput.placeholder = '编辑消息后点击保存';
-
-    focusInputEnd();
-  };
-
-  const applyActiveEdit = (nextContentRaw) => {
+  function applyActiveEdit(nextContentRaw) {
     if (!isEditing()) {
       return;
     }
 
-    const { conversationId, messageId, previousMessages, previousSelections } = activeEditState;
+    const {
+      conversationId,
+      messageId,
+      previousMessages,
+      previousSelections,
+      messageElement,
+      messageBody,
+      textarea,
+    } = activeEditState;
+
     const conversation = getConversations().find((entry) => entry.id === conversationId);
     if (!conversation) {
       cancelActiveEdit({ focusInput: false });
@@ -136,8 +156,19 @@ export function createEditingController({
     const message = conversation.messages[messageIndex];
     const normalizedCurrent =
       typeof message.content === 'string' ? message.content.replace(/\r\n/g, '\n') : '';
-    const normalizedNext =
-      typeof nextContentRaw === 'string' ? nextContentRaw.replace(/\r\n/g, '\n') : '';
+    const nextValueRaw =
+      typeof nextContentRaw === 'string'
+        ? nextContentRaw
+        : textarea instanceof HTMLTextAreaElement
+          ? textarea.value
+          : null;
+
+    if (typeof nextValueRaw !== 'string') {
+      cancelActiveEdit({ focusInput: true });
+      return;
+    }
+
+    const normalizedNext = nextValueRaw.replace(/\r\n/g, '\n');
 
     if (normalizedCurrent === normalizedNext) {
       cancelActiveEdit({ focusInput: true });
@@ -150,17 +181,25 @@ export function createEditingController({
     conversation.updatedAt = timestamp;
     bumpConversation(conversation.id);
 
-    const messageElement = findMessageElementById(messageId);
-    if (messageElement instanceof HTMLElement) {
-      const body = messageElement.querySelector('.message-content');
-      if (body) {
-        body.textContent = normalizedNext;
-        body.classList.remove('pending');
+    const targetElement =
+      messageElement instanceof HTMLElement
+        ? messageElement
+        : typeof findMessageElementById === 'function'
+          ? findMessageElementById(messageId)
+          : null;
+
+    if (targetElement instanceof HTMLElement) {
+      if (targetElement.dataset) {
+        targetElement.dataset.contentRaw = normalizedNext;
       }
-      if (messageElement.dataset) {
-        messageElement.dataset.contentRaw = normalizedNext;
+      const bodyNode =
+        messageBody instanceof HTMLElement ? messageBody : targetElement.querySelector('.message-content');
+      if (bodyNode) {
+        bodyNode.textContent = normalizedNext;
+        bodyNode.classList.remove('pending');
+        bodyNode.hidden = false;
       }
-      const timeElement = messageElement.querySelector('time');
+      const timeElement = targetElement.querySelector('time');
       if (timeElement) {
         timeElement.dateTime = timestamp;
         timeElement.textContent = new Date(timestamp).toLocaleTimeString('zh-CN', {
@@ -182,6 +221,127 @@ export function createEditingController({
     refreshConversationBranchNavigation(conversation);
 
     cancelActiveEdit({ focusInput: true });
+  }
+
+  const enterEditModeForMessage = ({
+    conversation,
+    message,
+    initialValue,
+    previousMessages,
+    previousSelections,
+    messageElement,
+    triggerButton,
+  }) => {
+    if (!conversation || !message) {
+      return;
+    }
+
+    const targetMessageElement =
+      messageElement instanceof HTMLElement
+        ? messageElement
+        : typeof findMessageElementById === 'function'
+          ? findMessageElementById(message.id)
+          : null;
+
+    if (!(targetMessageElement instanceof HTMLElement)) {
+      return;
+    }
+
+    cancelActiveEdit({ focusInput: false });
+
+    const contentNode = targetMessageElement.querySelector('.message-content');
+    const footerNode = targetMessageElement.querySelector('.message-footer');
+
+    const editorForm = document.createElement('form');
+    editorForm.className = 'message-edit-form';
+    editorForm.noValidate = true;
+
+    const textarea = document.createElement('textarea');
+    textarea.className = 'message-edit-textarea';
+    textarea.name = 'message-edit';
+    textarea.setAttribute('aria-label', '编辑消息内容');
+    textarea.autocomplete = 'off';
+    textarea.spellcheck = true;
+    textarea.value = typeof initialValue === 'string' ? initialValue : '';
+    const lineCount = textarea.value.split('\n').length;
+    textarea.rows = Math.min(Math.max(lineCount, 3), 12);
+    editorForm.appendChild(textarea);
+
+    const actions = document.createElement('div');
+    actions.className = 'message-edit-actions';
+
+    const cancelButtonInline = document.createElement('button');
+    cancelButtonInline.type = 'button';
+    cancelButtonInline.className = 'ghost-button message-edit-cancel';
+    cancelButtonInline.textContent = '取消';
+    cancelButtonInline.addEventListener('click', () => {
+      cancelActiveEdit({ focusInput: true });
+    });
+
+    const saveButtonInline = document.createElement('button');
+    saveButtonInline.type = 'submit';
+    saveButtonInline.className = 'primary-button message-edit-save';
+    saveButtonInline.textContent = '保存';
+
+    actions.append(cancelButtonInline, saveButtonInline);
+    editorForm.appendChild(actions);
+
+    editorForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      applyActiveEdit(textarea.value);
+    });
+
+    textarea.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && !event.isComposing && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault();
+        applyActiveEdit(textarea.value);
+      }
+    });
+
+    const bodyWasHidden = contentNode?.hidden ?? false;
+    if (contentNode instanceof HTMLElement) {
+      contentNode.hidden = true;
+    }
+
+    const footerWasHidden = footerNode?.hidden ?? false;
+    if (footerNode instanceof HTMLElement) {
+      footerNode.hidden = true;
+      footerNode.before(editorForm);
+    } else {
+      targetMessageElement.appendChild(editorForm);
+    }
+
+    targetMessageElement.classList.add('editing');
+    if (targetMessageElement.dataset) {
+      targetMessageElement.dataset.editing = 'true';
+    }
+
+    if (typeof setMessageActionsDisabled === 'function') {
+      setMessageActionsDisabled(targetMessageElement, true);
+    }
+
+    activeEditState = {
+      conversationId: conversation.id,
+      messageId: message.id,
+      previousMessages,
+      previousSelections,
+      messageElement: targetMessageElement,
+      messageBody: contentNode instanceof HTMLElement ? contentNode : null,
+      messageFooter: footerNode instanceof HTMLElement ? footerNode : null,
+      bodyWasHidden,
+      footerWasHidden,
+      editorForm,
+      textarea,
+      triggerButton: triggerButton instanceof HTMLElement ? triggerButton : null,
+    };
+
+    try {
+      textarea.focus();
+      const length = textarea.value.length;
+      textarea.setSelectionRange(length, length);
+    } catch (error) {
+      textarea.focus();
+    }
   };
 
   return {

--- a/frontend/elements.js
+++ b/frontend/elements.js
@@ -4,6 +4,7 @@ export const userInput = document.getElementById('user-input');
 export const cancelEditButton = document.getElementById('cancel-edit');
 export const chatEditingHint = document.getElementById('chat-editing-hint');
 export const chatPanel = document.querySelector('.chat-panel');
+export const appShell = document.querySelector('.app-shell');
 export const statusPill = document.getElementById('status-pill');
 export const modelLogList = document.getElementById('model-log');
 export const modelLogEmpty = document.getElementById('model-log-empty');

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -37,6 +37,10 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 @keyframes spin {
   to {
     transform: rotate(360deg);
@@ -52,7 +56,7 @@ body {
   height: var(--viewport-height);
   display: flex;
   align-items: stretch;
-  justify-content: center;
+  justify-content: flex-start;
   padding: var(--workspace-padding-block) var(--workspace-padding-inline);
   overflow: hidden;
 }
@@ -450,6 +454,66 @@ body.no-scroll { overflow: hidden; }
   color: var(--text-primary);
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.message.editing {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  box-shadow: var(--shadow-soft);
+  max-width: min(100%, 640px);
+}
+
+.message.user.editing {
+  margin-left: auto;
+}
+
+.message.editing .message-content {
+  display: none;
+}
+
+.message-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.message-edit-textarea {
+  width: 100%;
+  min-height: 6rem;
+  border-radius: 0.9rem;
+  border: 1px solid var(--border-color);
+  padding: 0.85rem 1rem;
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--text-primary);
+  background: var(--bg-app);
+  resize: vertical;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast), background-color var(--transition-fast);
+}
+
+.message-edit-textarea:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.08);
+  background: #ffffff;
+}
+
+.message-edit-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.message-edit-actions .ghost-button,
+.message-edit-actions .primary-button {
+  min-height: 2.25rem;
+}
+
+.message-edit-actions .message-edit-save {
+  padding-inline: 1.25rem;
 }
 
 .message .message-content p,


### PR DESCRIPTION
## Summary
- add Ctrl/Command+Enter shortcut on the chat input and inline editing controls for user messages
- redesign the editing controller to edit messages directly in place with localized action buttons and state restoration
- align the history sidebar with the full app shell height, ensure it docks on the far left, and update styles to support the new editing UI

## Testing
- Not run (frontend changes only)


------
https://chatgpt.com/codex/tasks/task_b_68e14d3e21408321ae5e3546049c9416