### PR TITLE
Fix SSE stream termination for non-SSE clients

### DIFF
--- a/src/okcvm/api/main.py
+++ b/src/okcvm/api/main.py
@@ -505,6 +505,13 @@ def create_app() -> FastAPI:
             payload.message[:120],
         )
         streaming_requested = payload.stream
+        accept_header = request.headers.get("accept", "")
+        accepts_event_stream = "text/event-stream" in accept_header.lower()
+        if streaming_requested and not accepts_event_stream:
+            logger.debug(
+                "Streaming requested but client does not accept event streams",
+            )
+            streaming_requested = False
         if streaming_requested:
             chat_config = get_config().chat
             if chat_config is None or not chat_config.supports_streaming:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,46 @@
+import asyncio
+
+from okcvm.streaming import EventStreamPublisher
+
+
+def test_event_stream_publisher_close_without_events():
+    async def main() -> None:
+        loop = asyncio.get_running_loop()
+        publisher = EventStreamPublisher(loop)
+
+        async def consume() -> list[bytes]:
+            chunks: list[bytes] = []
+            async for chunk in publisher.iter_sse():
+                chunks.append(chunk)
+            return chunks
+
+        task = asyncio.create_task(consume())
+        await asyncio.sleep(0)
+        publisher.close()
+        result = await task
+        assert result == []
+
+    asyncio.run(main())
+
+
+def test_event_stream_publisher_emits_final_event_and_terminates():
+    async def main() -> None:
+        loop = asyncio.get_running_loop()
+        publisher = EventStreamPublisher(loop)
+
+        async def consume() -> list[bytes]:
+            collected: list[bytes] = []
+            async for chunk in publisher.iter_sse():
+                collected.append(chunk)
+            return collected
+
+        task = asyncio.create_task(consume())
+
+        publisher.publish({"type": "final", "payload": {"reply": "done"}})
+        await asyncio.sleep(0)
+        publisher.close()
+
+        chunks = await task
+        assert chunks == [b'data: {"type": "final", "payload": {"reply": "done"}}\n\n']
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- ensure the chat endpoint only streams when the client explicitly accepts server-sent events
- make the event stream publisher enqueue a sentinel so iterators terminate cleanly on close
- add coverage around the publisher close behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e15b66a32c83218d684a0c1f401a79