### PR TITLE
Fix message action click handling for SVG targets

### DIFF
--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -498,7 +498,7 @@ function initializeEventListeners() {
 
   if (chatMessages) {
     chatMessages.addEventListener('click', async (event) => {
-      const origin = event.target instanceof HTMLElement ? event.target : null;
+      const origin = event.target instanceof Element ? event.target : null;
       if (!origin) return;
 
       const navButton = origin.closest('button.branch-nav-button');
@@ -555,7 +555,7 @@ function initializeEventListeners() {
 
   if (conversationList) {
     conversationList.addEventListener('click', (event) => {
-      const target = event.target instanceof HTMLElement ? event.target : null;
+      const target = event.target instanceof Element ? event.target : null;
       if (!target) return;
 
       const deleteButton = target.closest('button[data-action="delete"]');

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -498,7 +498,7 @@ function initializeEventListeners() {
 
   if (chatMessages) {
     chatMessages.addEventListener('click', async (event) => {
-      const origin = event.target instanceof Element ? event.target : null;
+      const origin = event.target instanceof Element ? event.target : event.target.parentElement;
       if (!origin) return;
 
       const navButton = origin.closest('button.branch-nav-button');

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -555,7 +555,7 @@ function initializeEventListeners() {
 
   if (conversationList) {
     conversationList.addEventListener('click', (event) => {
-      const target = event.target instanceof Element ? event.target : null;
+      const target = event.target instanceof Element ? event.target : event.target.parentElement;
       if (!target) return;
 
       const deleteButton = target.closest('button[data-action="delete"]');


### PR DESCRIPTION
## Summary
- allow delegated click handlers on chat messages and conversation list to work when the event originates from SVG icons
- resolve the issue where edit/refresh/delete buttons required clicking the surrounding padding instead of the icon itself

## Testing
- Manual testing via Playwright to confirm the inline editor opens when clicking the edit icon

------
https://chatgpt.com/codex/tasks/task_b_68e1638bafdc8321a190a81471f5f91a