### PR TITLE
Update edit message button label to send

### DIFF
--- a/frontend/app/editingController.js
+++ b/frontend/app/editingController.js
@@ -281,7 +281,7 @@ export function createEditingController({
     const saveButtonInline = document.createElement('button');
     saveButtonInline.type = 'submit';
     saveButtonInline.className = 'primary-button message-edit-save';
-    saveButtonInline.textContent = '保存';
+    saveButtonInline.textContent = '发送';
 
     actions.append(cancelButtonInline, saveButtonInline);
     editorForm.appendChild(actions);

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -54,7 +54,7 @@ const sendButton = chatForm?.querySelector('.send-button') ?? null;
 
 const defaultSendButtonLabel = sendButton?.textContent?.trim() || '发送';
 const defaultInputPlaceholder = userInput?.getAttribute('placeholder') ?? '';
-const editingHintFallback = '正在编辑历史消息，点击“保存”完成修改。';
+const editingHintFallback = '正在编辑历史消息，点击“发送”完成修改。';
 const editingHintInitial = chatEditingHint?.textContent?.trim();
 const defaultEditingHintText =
   editingHintInitial && editingHintInitial.length > 0 ? editingHintInitial : editingHintFallback;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -75,7 +75,7 @@
                 required
               ></textarea>
               <p class="chat-input-hint" id="chat-editing-hint" hidden>
-                正在编辑历史消息，点击“保存”完成修改。
+                正在编辑历史消息，点击“发送”完成修改。
               </p>
             </div>
             <div class="chat-input-actions">


### PR DESCRIPTION
## Summary
- rename the inline edit action button from "保存" to "发送"
- update edit-mode hint text to reflect the new "发送" label in both HTML and JS fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e1ebd9e9cc8321ba8d6ef84a326af1