### PR TITLE
Restore assistant markdown rendering

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -430,7 +430,7 @@ body.no-scroll { overflow: hidden; }
 .message.user {
   margin-left: auto;
   background: var(--bg-muted);
-  border: 1px solid var(--border-color);
+  border: none;
 }
 
 .message.assistant {


### PR DESCRIPTION
## Summary
- render assistant chat messages through the shared Markdown pipeline so replies show formatted content again
- centralize message body updates to reuse Markdown rendering and keep dataset metadata in sync
- remove the dark border from user message bubbles for a cleaner appearance

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e1f8014e6483218e6163acbc7c6595