### PR TITLE
Adjust main workspace width to 80% of screen

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -73,6 +73,13 @@ body.no-scroll { overflow: hidden; }
   flex-wrap: wrap;
   min-height: calc(var(--viewport-height) - (var(--workspace-padding-block) * 2));
   height: calc(var(--viewport-height) - (var(--workspace-padding-block) * 2));
+  margin: 0 auto;
+}
+
+@media (min-width: 1024px) {
+  .app-workspace {
+    width: min(1600px, 80vw);
+  }
 }
 
 .app-shell {
@@ -109,7 +116,6 @@ body.no-scroll { overflow: hidden; }
   gap: 1rem;
   text-align: center;
   width: 100%;
-  max-width: 960px;
   margin: 0 auto;
 }
 .logo-area {
@@ -424,7 +430,6 @@ body.no-scroll { overflow: hidden; }
   flex: 1;
   min-height: 0;
   width: 100%;
-  max-width: 960px;
   margin: 0 auto;
   justify-content: center;
 }


### PR DESCRIPTION
## Summary
- widen the main workspace layout to better utilize available screen width
- remove legacy max-width limits on the header and main areas so they fill the expanded workspace
- apply a responsive rule to size the workspace to 80% of the viewport on large displays while keeping full width on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e20f6978b88321bd25ce2651adf1a3