### PR TITLE
Keep reasoning logs accessible in the chat UI

### DIFF
--- a/frontend/app/messageRenderer.js
+++ b/frontend/app/messageRenderer.js
@@ -273,7 +273,7 @@ export function createMessageRenderer({
 
     const summary = document.createElement('summary');
     const stepCount = steps.length;
-    summary.textContent = stepCount > 0 ? `推理完成（共${stepCount}步，点击展开）` : '推理完成（点击展开）';
+    summary.textContent = `推理完成（共${stepCount}步，点击展开）`;
     details.appendChild(summary);
 
     const body = document.createElement('div');

--- a/frontend/app/messageRenderer.js
+++ b/frontend/app/messageRenderer.js
@@ -262,7 +262,7 @@ export function createMessageRenderer({
       return null;
     }
 
-    const steps = Array.from(toolContainer.children || []).filter((node) => node instanceof HTMLElement);
+    const steps = Array.from(toolContainer.children);
     if (steps.length === 0) {
       return null;
     }

--- a/frontend/app/messageRenderer.js
+++ b/frontend/app/messageRenderer.js
@@ -246,7 +246,51 @@ export function createMessageRenderer({
     return { messageId, messageElement };
   };
 
-  const finalizePendingMessage = (message, text, messageId) => {
+  const createReasoningDetails = (reasoningOptions) => {
+    if (!reasoningOptions || typeof reasoningOptions !== 'object') {
+      return null;
+    }
+
+    const { toolContainer, statusElement } = reasoningOptions;
+
+    if (statusElement instanceof HTMLElement) {
+      statusElement.textContent = '推理完成';
+      statusElement.dataset.status = 'done';
+    }
+
+    if (!(toolContainer instanceof HTMLElement)) {
+      return null;
+    }
+
+    const steps = Array.from(toolContainer.children || []).filter((node) => node instanceof HTMLElement);
+    if (steps.length === 0) {
+      return null;
+    }
+
+    const details = document.createElement('details');
+    details.className = 'reasoning-details';
+    details.open = false;
+
+    const summary = document.createElement('summary');
+    const stepCount = steps.length;
+    summary.textContent = stepCount > 0 ? `推理完成（共${stepCount}步，点击展开）` : '推理完成（点击展开）';
+    details.appendChild(summary);
+
+    const body = document.createElement('div');
+    body.className = 'reasoning-details-body';
+
+    const historyContainer = document.createElement('div');
+    historyContainer.className = 'tool-status-container';
+    steps.forEach((node) => {
+      historyContainer.appendChild(node.cloneNode(true));
+    });
+
+    body.appendChild(historyContainer);
+    details.appendChild(body);
+    return details;
+  };
+
+  const finalizePendingMessage = (message, text, messageId, options = {}) => {
     const finalText = typeof text === 'string' ? text : '';
     if (!(message instanceof HTMLElement)) {
       if (messageId) {
@@ -263,6 +307,8 @@ export function createMessageRenderer({
       return;
     }
 
+    const reasoningDetails = createReasoningDetails(options.reasoning ?? null);
+
     setMessageContent(message, finalText);
 
     message.classList.remove('pending');
@@ -272,6 +318,13 @@ export function createMessageRenderer({
     }
     message.removeAttribute('data-pending');
     messageActions.setMessageActionsDisabled(message, false);
+
+    if (reasoningDetails) {
+      const body = message.querySelector('.message-content');
+      if (body instanceof HTMLElement) {
+        body.appendChild(reasoningDetails);
+      }
+    }
 
     if (messageId) {
       const conversation = resolvePendingConversationMessage(messageId, finalText);

--- a/frontend/app/streamingController.js
+++ b/frontend/app/streamingController.js
@@ -2,12 +2,12 @@ import { streamJson } from '../utils.js';
 
 function setupStreamingUI(messageElement) {
   if (!(messageElement instanceof HTMLElement)) {
-    return { textElement: null, toolContainer: null };
+    return { textElement: null, toolContainer: null, statusElement: null };
   }
 
   const body = messageElement.querySelector('.message-content');
   if (!(body instanceof HTMLElement)) {
-    return { textElement: null, toolContainer: null };
+    return { textElement: null, toolContainer: null, statusElement: null };
   }
 
   body.innerHTML = '';
@@ -18,12 +18,22 @@ function setupStreamingUI(messageElement) {
   textElement.className = 'streaming-text';
   wrapper.appendChild(textElement);
 
+  const reasoningWrapper = document.createElement('div');
+  reasoningWrapper.className = 'reasoning-wrapper';
+
+  const statusElement = document.createElement('div');
+  statusElement.className = 'reasoning-header';
+  statusElement.textContent = '推理中';
+  reasoningWrapper.appendChild(statusElement);
+
   const toolContainer = document.createElement('div');
   toolContainer.className = 'tool-status-container';
-  wrapper.appendChild(toolContainer);
+  reasoningWrapper.appendChild(toolContainer);
+
+  wrapper.appendChild(reasoningWrapper);
 
   body.appendChild(wrapper);
-  return { textElement, toolContainer };
+  return { textElement, toolContainer, statusElement };
 }
 
 function formatToolDuration(durationMs) {
@@ -79,18 +89,31 @@ function renderToolEvent(toolContainer, registry, event) {
 
   if (event.type === 'tool_completed') {
     const { card, status, body, startedAt } = existing;
-    status.textContent = '已完成';
-    card.dataset.status = 'done';
+    const isError = event.status === 'error';
+    status.textContent = isError ? '执行失败' : '已完成';
+    card.dataset.status = isError ? 'error' : 'done';
+    card.classList.toggle('error', isError);
+    card.classList.toggle('completed', !isError);
     const duration = formatToolDuration(Date.now() - (startedAt ?? Date.now()));
     if (duration) {
       status.textContent += ` · ${duration}`;
     }
 
-    if (event.output !== undefined) {
+    if (isError) {
+      const errorMessage =
+        typeof event.error === 'string' && event.error.trim()
+          ? event.error.trim()
+          : '工具执行失败';
+      const errorParagraph = document.createElement('p');
+      errorParagraph.className = 'tool-status-error';
+      errorParagraph.textContent = errorMessage;
+      body.appendChild(errorParagraph);
+    } else if (event.output !== undefined) {
       const pre = document.createElement('pre');
       pre.textContent = JSON.stringify(event.output, null, 2);
       body.appendChild(pre);
     }
+    registry.delete(invocationId);
     return;
   }
 }
@@ -99,11 +122,13 @@ export function createStreamingController({ finalizePendingMessage }) {
   const runAssistantStream = async (messageElement, messageId, requestBody, { onSuccess } = {}) => {
     let textElement = null;
     let toolContainer = null;
+    let statusElement = null;
 
     if (messageElement instanceof HTMLElement) {
       const setup = setupStreamingUI(messageElement);
       textElement = setup.textElement;
       toolContainer = setup.toolContainer;
+      statusElement = setup.statusElement;
     }
 
     const toolRegistry = new Map();
@@ -143,7 +168,12 @@ export function createStreamingController({ finalizePendingMessage }) {
       throw new Error('模型返回为空');
     }
 
-    finalizePendingMessage(messageElement, payload.reply, messageId);
+    finalizePendingMessage(messageElement, payload.reply, messageId, {
+      reasoning:
+        toolContainer instanceof HTMLElement
+          ? { toolContainer, statusElement: statusElement ?? null }
+          : null,
+    });
     if (typeof onSuccess === 'function') {
       onSuccess(payload);
     }

--- a/frontend/app/streamingController.js
+++ b/frontend/app/streamingController.js
@@ -100,10 +100,7 @@ function renderToolEvent(toolContainer, registry, event) {
     }
 
     if (isError) {
-      const errorMessage =
-        typeof event.error === 'string' && event.error.trim()
-          ? event.error.trim()
-          : '工具执行失败';
+      const errorMessage = (typeof event.error === 'string' && event.error.trim()) || '工具执行失败';
       const errorParagraph = document.createElement('p');
       errorParagraph.className = 'tool-status-error';
       errorParagraph.textContent = errorMessage;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -637,6 +637,51 @@ body.no-scroll { overflow: hidden; }
   line-height: 1.65;
 }
 
+.message .reasoning-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.35rem 0.6rem 0.6rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.45);
+  border: 1px dashed rgba(0, 0, 0, 0.1);
+}
+
+.message .reasoning-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.message .reasoning-header::before {
+  content: '';
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--accent-color);
+  animation: reasoning-pulse 1.4s ease-in-out infinite;
+}
+
+.message .reasoning-header[data-status='done']::before {
+  animation: none;
+  background: var(--accent-strong);
+}
+
+@keyframes reasoning-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  50% {
+    transform: scale(1.3);
+    opacity: 1;
+  }
+}
+
 .message .tool-status-container {
   display: flex;
   flex-direction: column;
@@ -668,6 +713,13 @@ body.no-scroll { overflow: hidden; }
   background: rgba(217, 72, 72, 0.08);
 }
 
+.message .tool-status-error {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: #b03535;
+  word-break: break-word;
+}
+
 .message .tool-status-title {
   font-weight: 600;
   color: var(--text-primary);
@@ -689,6 +741,45 @@ body.no-scroll { overflow: hidden; }
   margin-top: 0.5rem;
   font-size: 0.85rem;
   color: var(--text-secondary);
+}
+
+.message .reasoning-details {
+  margin-top: 0.9rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.88);
+}
+
+.message .reasoning-details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text-secondary);
+  padding: 0.65rem 0.9rem;
+  list-style: none;
+}
+
+.message .reasoning-details summary::marker,
+.message .reasoning-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.message .reasoning-details summary::after {
+  content: '展开';
+  font-size: 0.75rem;
+  margin-left: 0.5rem;
+  color: var(--accent-color);
+}
+
+.message .reasoning-details[open] summary::after {
+  content: '收起';
+}
+
+.message .reasoning-details[open] summary {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.message .reasoning-details-body {
+  padding: 0.8rem 0.9rem 0.9rem;
 }
 .message-footer {
   display: flex;


### PR DESCRIPTION
## Summary
- show a "推理中" indicator around the streaming tool updates while the assistant reply is being generated
- preserve streamed tool reasoning cards after completion by collapsing them into a "推理完成" details block
- add styling for the new reasoning badge, collapsible section, and error messaging states

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_b_68e23a1e1d10832193d95a832e54c54f