### PR TITLE
Refresh architecture and roadmap documentation for streaming updates

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,20 +7,27 @@ Python orchestrator, FastAPI API, and static operator console loosely coupled.
 ## Subsystem map
 
 1. **Specification bundle** – The upstream system prompt and tool manifest live
-   in [`spec/system_prompt.md`](../spec/system_prompt.md) and [`spec/tools.json`](../spec/tools.json). `okcvm.spec` exposes dataclasses and
-   helpers that parse these assets, providing typed accessors for downstream
-   modules. [src/okcvm/spec.py#L1-L168](../src/okcvm/spec.py#L1-L168)
+   in [`spec/system_prompt.md`](../spec/system_prompt.md) and [`spec/tools.json`](../spec/tools.json).
+   `okcvm.spec` exposes data classes and helpers that parse these assets,
+   providing typed accessors for downstream modules.
+   [src/okcvm/spec.py#L1-L168](../src/okcvm/spec.py#L1-L168)
 2. **Runtime core** – Modules under [`src/okcvm/`](../src/okcvm) handle
-   configuration, logging, registry wiring, LangChain integration, workspace
-   management, and session lifecycle. They are pure Python and power both the CLI
-   and API surfaces. [src/okcvm/config.py#L25-L227](../src/okcvm/config.py#L25-L227) [src/okcvm/vm.py#L26-L178](../src/okcvm/vm.py#L26-L178)
+   configuration, logging, tool registration, LangChain orchestration, streaming
+   callbacks, workspace management, and session lifecycle for both CLI and API
+   surfaces. [src/okcvm/config.py#L49-L374](../src/okcvm/config.py#L49-L374)
+   [src/okcvm/vm.py#L30-L245](../src/okcvm/vm.py#L30-L245)
+   [src/okcvm/streaming.py#L33-L165](../src/okcvm/streaming.py#L33-L165)
 3. **HTTP API** – [`okcvm.api.main`](../src/okcvm/api/main.py) wraps FastAPI,
-   serves static assets, implements authentication-free REST endpoints, and keeps
-   multi-client session state in-memory via `SessionStore` and a lightweight
-   `AppState` helper. [src/okcvm/api/main.py#L58-L309](../src/okcvm/api/main.py#L58-L309)
+   serves static assets, exposes REST and streaming endpoints, manages the
+   conversation store, and keeps multi-client session state in-memory via
+   `SessionStore`. [src/okcvm/api/main.py#L30-L781](../src/okcvm/api/main.py#L30-L781)
 4. **Control panel frontend** – Static assets in [`frontend/`](../frontend)
-   deliver the dashboard experience with persistent conversations, settings
-   management, preview panes, and telemetry timelines. [frontend/index.html#L16-L220](../frontend/index.html#L16-L220) [frontend/app.js#L1-L720](../frontend/app.js#L1-L720)
+   deliver the operator console with persistent conversations, upload workflows,
+   streaming transcripts, preview panes, and telemetry timelines.
+   [frontend/index.html#L16-L220](../frontend/index.html#L16-L220)
+   [frontend/app/index.js#L1-L360](../frontend/app/index.js#L1-L360)
+   [frontend/app/streamingController.js#L1-L183](../frontend/app/streamingController.js#L1-L183)
+   [frontend/conversationState.js#L1-L810](../frontend/conversationState.js#L1-L810)
 
 ## Request lifecycle
 
@@ -29,40 +36,60 @@ Python orchestrator, FastAPI API, and static operator console loosely coupled.
    up Uvicorn pointed at `okcvm.api.main:app`. [src/okcvm/server.py#L1-L88](../src/okcvm/server.py#L1-L88)
 2. **Session boot** – On the first API call, `SessionStore` provisions a
    `SessionState` keyed by the caller’s `client_id`, attaches a `WorkspaceManager`,
-   loads the canonical prompt, and instantiates a `VirtualMachine` bound to the
-   default tool registry. [src/okcvm/api/main.py#L58-L209](../src/okcvm/api/main.py#L58-L209) [src/okcvm/session.py#L22-L90](../src/okcvm/session.py#L22-L90)
-3. **Chat execution** – The virtual machine adapts chat history into LangChain
-   message objects, invokes the configured model, records tool calls, and returns
-   a structured payload with normalised previews and artefacts consumed by the
-   frontend. [src/okcvm/vm.py#L58-L178](../src/okcvm/vm.py#L58-L178) [src/okcvm/session.py#L94-L279](../src/okcvm/session.py#L94-L279)
+   patches the canonical prompt with upload hints, and instantiates a
+   `VirtualMachine` bound to the registered tools.
+   [src/okcvm/api/main.py#L30-L420](../src/okcvm/api/main.py#L30-L420)
+   [src/okcvm/session.py#L30-L153](../src/okcvm/session.py#L30-L153)
+3. **Chat execution** – The virtual machine adapts history into LangChain
+   messages, streams tokens and tool telemetry via SSE when requested, records
+   tool calls, and returns enriched previews, artefacts, uploads, and workspace
+   state for the frontend. [src/okcvm/vm.py#L58-L245](../src/okcvm/vm.py#L58-L245)
+   [src/okcvm/session.py#L277-L519](../src/okcvm/session.py#L277-L519)
+   [src/okcvm/streaming.py#L33-L165](../src/okcvm/streaming.py#L33-L165)
 4. **Workspace snapshotting** – After each response, the workspace state takes a
-   Git snapshot and exposes metadata (latest commit, snapshot list, workspace
-   mount paths) via the session object so the UI can render the session tree. [src/okcvm/session.py#L94-L369](../src/okcvm/session.py#L94-L369) [src/okcvm/workspace.py#L32-L211](../src/okcvm/workspace.py#L32-L211)
-5. **Frontend rendering** – The browser client fetches configuration and session
-   info, renders conversation threads, writes HTML previews into an iframe, and
-   streams telemetry into the model log timeline. [frontend/app.js#L260-L720](../frontend/app.js#L260-L720)
+   Git snapshot and exposes metadata (latest commit, snapshot list, mount paths)
+   so the UI and conversation store can render the session tree.
+   [src/okcvm/session.py#L277-L588](../src/okcvm/session.py#L277-L588)
+   [src/okcvm/workspace.py#L112-L332](../src/okcvm/workspace.py#L112-L332)
+5. **Frontend rendering** – The browser client syncs configuration,
+   conversations, uploads, and workspace metadata; renders branches; streams
+   incremental tokens; and updates previews and telemetry panes.
+   [frontend/app/index.js#L270-L360](../frontend/app/index.js#L270-L360)
+   [frontend/conversationState.js#L612-L810](../frontend/conversationState.js#L612-L810)
+   [frontend/app/streamingController.js#L118-L182](../frontend/app/streamingController.js#L118-L182)
 
 ## Data boundaries and storage
 
-- **Configuration** – In-memory dataclasses represent chat/media endpoints and
-  can be mutated via CLI, YAML, environment variables, or `/api/config`
-  requests. [src/okcvm/config.py#L25-L227](../src/okcvm/config.py#L25-L227) [src/okcvm/api/main.py#L210-L256](../src/okcvm/api/main.py#L210-L256)
+- **Configuration** – In-memory dataclasses represent chat/media endpoints,
+  conversation-store settings, and workspace roots. They can be mutated via CLI,
+  YAML, environment variables, or `/api/config` requests.
+  [src/okcvm/config.py#L49-L374](../src/okcvm/config.py#L49-L374)
+  [src/okcvm/api/main.py#L423-L523](../src/okcvm/api/main.py#L423-L523)
 - **Session history** – Stored in-process within `VirtualMachine`, including
-  references to tool inputs/outputs and workspace snapshots for branchable
-  timelines. [src/okcvm/vm.py#L118-L178](../src/okcvm/vm.py#L118-L178)
+  tool traces, uploads, and snapshot identifiers for branchable timelines.
+  [src/okcvm/vm.py#L118-L245](../src/okcvm/vm.py#L118-L245)
 - **Workspace** – Each session receives a namespaced directory tree, optionally
-  Git-backed, to isolate file operations and persist artefacts between requests. [src/okcvm/workspace.py#L32-L211](../src/okcvm/workspace.py#L32-L211)
-- **Frontend cache** – `localStorage` holds conversation metadata and the
-  generated `client_id` for quick restoration after reloads; the backend remains
-  stateless beyond workspace directories. [frontend/utils.js#L1-L120](../frontend/utils.js#L1-L120) [frontend/conversationState.js#L1-L240](../frontend/conversationState.js#L1-L240)
+  Git-backed, to isolate file operations, uploaded assets, and tool outputs.
+  [src/okcvm/workspace.py#L120-L332](../src/okcvm/workspace.py#L120-L332)
+- **Conversation store** – Persisted conversations live in the SQL-backed store
+  so the UI can restore message graphs, previews, and workspace metadata across
+  reloads. [src/okcvm/storage/conversations.py#L81-L318](../src/okcvm/storage/conversations.py#L81-L318)
+- **Frontend cache** – `localStorage` holds client identifiers while the REST
+  API exposes full conversation data. Upload manifests and previews travel with
+  each response. [frontend/utils.js#L1-L300](../frontend/utils.js#L1-L300)
+  [frontend/conversationState.js#L612-L810](../frontend/conversationState.js#L612-L810)
 
 ## Testing and observability
 
-- `pytest` covers API routes, workspace guarantees, and VM behaviour. The suite
-  lives under [`tests/`](../tests) with fixtures in `conftest.py`. [tests/test_api_app.py#L1-L145](../tests/test_api_app.py#L1-L145) [tests/test_workspace.py#L1-L24](../tests/test_workspace.py#L1-L24)
+- `pytest` covers API routes, workspace guarantees, streaming handlers, storage,
+  and VM behaviour. The suite lives under [`tests/`](../tests) with fixtures in
+  `conftest.py`. [tests/test_api_app.py#L1-L361](../tests/test_api_app.py#L1-L361)
+  [tests/test_streaming.py#L1-L110](../tests/test_streaming.py#L1-L110)
+  [tests/test_storage_conversations.py#L1-L132](../tests/test_storage_conversations.py#L1-L132)
 - Structured logs are emitted via `RequestLoggingMiddleware` and the shared
   logging utilities, enabling trace correlation between API calls and agent
-  activity. [src/okcvm/api/main.py#L30-L87](../src/okcvm/api/main.py#L30-L87) [src/okcvm/logging_utils.py#L1-L115](../src/okcvm/logging_utils.py#L1-L115)
+  activity. [src/okcvm/api/main.py#L105-L138](../src/okcvm/api/main.py#L105-L138)
+  [src/okcvm/logging_utils.py#L1-L146](../src/okcvm/logging_utils.py#L1-L146)
 
 This layered architecture keeps the project modular: the runtime core can power
 other interfaces, and the frontend can evolve independently while consuming the

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -5,66 +5,85 @@ tool catalogue, LangChain-powered runtime, and a FastAPI surface. This document
 covers the moving parts you will touch most often when extending the system.
 
 ## Configuration management
-- [`okcvm.config`](../src/okcvm/config.py) defines dataclasses for chat endpoints,
-  media providers, and workspace settings. It supports layered loading from YAML,
-  environment variables, and in-memory overrides, exposing thread-safe `configure`
-  and `get_config` helpers for both CLI and API callers. [src/okcvm/config.py#L25-L227](../src/okcvm/config.py#L25-L227)
-- `load_config_from_yaml` resolves relative paths against the project root,
-  applies defaults, and prepares workspace directories before runtime
-  initialisation. [src/okcvm/config.py#L177-L227](../src/okcvm/config.py#L177-L227)
-- The FastAPI `/api/config` route deserialises incoming payloads into the same
-  dataclasses, redacts secrets in logs, and reuses `configure` so operators can
-  adjust credentials without restarts. [src/okcvm/api/main.py#L210-L256](../src/okcvm/api/main.py#L210-L256)
-- Request payloads flow through [`okcvm.api.models`](../src/okcvm/api/models.py),
-  which maps JSON into runtime dataclasses while preserving unset API keys and
-  validating snapshot operations. [src/okcvm/api/models.py#L1-L80](../src/okcvm/api/models.py#L1-L80)
+- [`okcvm.config`](../src/okcvm/config.py) defines dataclasses for chat/media
+  endpoints, workspace settings, and the SQL-backed conversation store while
+  keeping a thread-safe global `Config`. CLI and API callers therefore read the
+  same state. [src/okcvm/config.py#L49-L307](../src/okcvm/config.py#L49-L307)
+- `load_config_from_yaml` resolves relative paths, prepares the workspace
+  directory, and merges YAML values with environment overrides before calling
+  `configure`. [src/okcvm/config.py#L311-L374](../src/okcvm/config.py#L311-L374)
+- The FastAPI `/api/config` route maps payloads into the endpoint dataclasses,
+  preserves previously supplied secrets, and applies the update atomically.
+  [src/okcvm/api/main.py#L423-L523](../src/okcvm/api/main.py#L423-L523)
+- Request models in [`okcvm.api.models`](../src/okcvm/api/models.py) validate
+  streaming flags, workspace snapshot payloads, and conversation persistence
+  updates while ensuring unset API keys are not cleared accidentally.
+  [src/okcvm/api/models.py#L10-L95](../src/okcvm/api/models.py#L10-L95)
 
 ## Tool registry and workspace injection
 - [`okcvm.registry.ToolRegistry`](../src/okcvm/registry.py) parses the packaged
   tool specification, registers Python implementations, and injects a
   `WorkspaceManager` into tools that declare `requires_workspace`, ensuring file
-  operations stay within the session sandbox. [src/okcvm/registry.py#L1-L200](../src/okcvm/registry.py#L1-L200)
+  operations stay within the session sandbox. [src/okcvm/registry.py#L1-L175](../src/okcvm/registry.py#L1-L175)
 - Custom tools live in [`okcvm/tools`](../src/okcvm/tools). Highlights include
   deployment helpers, slide generation, shell access, and data ingestion stubs.
   Each tool adheres to the manifest schema and often wraps shared helpers from
-  `okcvm.tools.base`. [src/okcvm/tools/deployment.py#L40-L208](../src/okcvm/tools/deployment.py#L40-L208) [src/okcvm/tools/slides.py#L12-L78](../src/okcvm/tools/slides.py#L12-L78)
+  `okcvm.tools.base`. [src/okcvm/tools/deployment.py#L44-L320](../src/okcvm/tools/deployment.py#L44-L320)
+  [src/okcvm/tools/slides.py#L1-L108](../src/okcvm/tools/slides.py#L1-L108)
 
 ## LangChain integration
-- [`okcvm.llm.create_llm_chain`](../src/okcvm/llm.py) builds a LangChain
-  `AgentExecutor` backed by the configured chat model, binds registered tools, and
-  returns a callable used by the virtual machine for every chat turn. [src/okcvm/llm.py#L13-L57](../src/okcvm/llm.py#L13-L57)
-- [`okcvm.vm.VirtualMachine`](../src/okcvm/vm.py) stores conversation history,
-  lazily constructs the LangChain chain, adapts messages into the required
-  structure, records tool invocations, and generates telemetry for the
-  frontend. [src/okcvm/vm.py#L26-L178](../src/okcvm/vm.py#L26-L178)
-- [`okcvm.session.SessionState`](../src/okcvm/session.py) orchestrates the runtime
-  by wiring the registry, VM, and workspace together. It exposes high-level
-  methods (`boot`, `respond`, `snapshot_workspace`, etc.) consumed by the API and
-  returns JSON-ready payloads with normalised previews, deduplicated artefacts,
-  and client-aware URLs for the frontend. [src/okcvm/session.py#L22-L279](../src/okcvm/session.py#L22-L279)
+- [`okcvm.llm.create_llm_chain`](../src/okcvm/llm.py) constructs a
+  tool-calling `AgentExecutor` using the configured chat endpoint, propagating
+  the streaming flag so server-sent events mirror provider capabilities.
+  [src/okcvm/llm.py#L15-L75](../src/okcvm/llm.py#L15-L75)
+- [`okcvm.vm.VirtualMachine`](../src/okcvm/vm.py) keeps structured history,
+  adapts turns for LangChain, and records tool invocations for the UI while
+  exposing direct tool calls. [src/okcvm/vm.py#L30-L245](../src/okcvm/vm.py#L30-L245)
+- [`okcvm.session.SessionState`](../src/okcvm/session.py) enriches the VM output
+  with previews, workspace snapshots, uploaded file manifests, and regenerated
+  metadata for streaming handlers and synchronous responses alike.
+  [src/okcvm/session.py#L30-L589](../src/okcvm/session.py#L30-L589)
+- [`okcvm.streaming`](../src/okcvm/streaming.py) forwards LangChain callback
+  events (tokens, tool starts/completions) through an SSE publisher consumed by
+  the `/api/chat` streaming mode. [src/okcvm/streaming.py#L33-L165](../src/okcvm/streaming.py#L33-L165)
 
 ## FastAPI surface
-- [`okcvm.api.main`](../src/okcvm/api/main.py) creates the FastAPI app, mounts the
-  static frontend, adds CORS and structured request logging middleware, and keeps
-  track of per-client sessions via `SessionStore` and the shared `AppState`
-  helper. [src/okcvm/api/main.py#L30-L206](../src/okcvm/api/main.py#L30-L206)
-- REST endpoints expose configuration CRUD, session boot, chat, history lookup,
-  workspace snapshot management, and deployment asset serving. `_resolve_deployment_asset`
-  enforces path safety while appending `client_id` context so previews remain
-  scoped to the requesting session. Error handling normalises exceptions into
-  HTTP responses with helpful messages for operators. [src/okcvm/api/main.py#L146-L309](../src/okcvm/api/main.py#L146-L309)
+- [`okcvm.api.main`](../src/okcvm/api/main.py) wires middleware, mounts the
+  static frontend, and coordinates per-client `SessionState` instances via a
+  thread-safe `SessionStore`. [src/okcvm/api/main.py#L30-L420](../src/okcvm/api/main.py#L30-L420)
+- REST endpoints cover configuration CRUD, conversation persistence, workspace
+  snapshot management, history inspection, and deployment asset serving while
+  automatically injecting upload constraints. [src/okcvm/api/main.py#L423-L703](../src/okcvm/api/main.py#L423-L703)
+- `/api/chat` supports both synchronous replies and streaming SSE sessions,
+  relaying incremental tokens and tool telemetry via `LangChainStreamingHandler`.
+  [src/okcvm/api/main.py#L705-L781](../src/okcvm/api/main.py#L705-L781)
+
+## Conversation persistence
+- [`okcvm.storage.conversations`](../src/okcvm/storage/conversations.py)
+  provisions a SQLAlchemy model per client, persists full conversation graphs,
+  and cleans up workspace artefacts when sessions are deleted.
+  [src/okcvm/storage/conversations.py#L21-L318](../src/okcvm/storage/conversations.py#L21-L318)
+- `get_conversation_store` caches the engine based on the active config and is
+  reused by the conversation REST endpoints.
+  [src/okcvm/storage/conversations.py#L321-L339](../src/okcvm/storage/conversations.py#L321-L339)
 
 ## Command line interface
 - [`okcvm.server:cli`](../src/okcvm/server.py) is a Typer app that loads
   configuration, verifies workspace paths, and launches Uvicorn. Use
-  `python -m okcvm.server --reload` for local development or embed the CLI into
+  `python -m okcvm.server --reload` for development or embed the CLI into
   supervisor scripts in production. [src/okcvm/server.py#L1-L88](../src/okcvm/server.py#L1-L88)
 - The legacy entrypoint in [`main.py`](../main.py) still exposes Typer commands
-  for compatibility; prefer the dedicated server module for new tooling. [main.py#L1-L175](../main.py#L1-L175)
+  for compatibility; prefer the dedicated server module for new tooling.
+  [main.py#L1-L175](../main.py#L1-L175)
 
 ## Testing
 - `pytest` coverage spans configuration, FastAPI routes, virtual machine
-  behaviour, workspace safety, and tool interactions. Start with [`tests/test_api_app.py`](../tests/test_api_app.py) and [`tests/test_workspace.py`](../tests/test_workspace.py) when debugging
-  regressions. [tests/test_api_app.py#L1-L145](../tests/test_api_app.py#L1-L145) [tests/test_workspace.py#L1-L24](../tests/test_workspace.py#L1-L24)
+  behaviour, workspace safety, streaming handlers, storage, and tool
+  interactions. Start with [`tests/test_api_app.py`](../tests/test_api_app.py),
+  [`tests/test_storage_conversations.py`](../tests/test_storage_conversations.py), and
+  [`tests/test_workspace.py`](../tests/test_workspace.py) when debugging
+  regressions. [tests/test_api_app.py#L1-L361](../tests/test_api_app.py#L1-L361)
+  [tests/test_storage_conversations.py#L1-L132](../tests/test_storage_conversations.py#L1-L132)
+  [tests/test_workspace.py#L1-L74](../tests/test_workspace.py#L1-L74)
 - Add regression tests alongside new features; the suite runs quickly and is a
   prerequisite for merging into main.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -5,77 +5,97 @@ bundle by FastAPI. It focuses on clarity, offline readiness, and presenting agen
 activity in a way that supports rapid iteration.
 
 ## Layout and accessibility
-- [`index.html`](../frontend/index.html) defines the workspace header, chat
-  surface, insight column, and history sidebar using landmark roles, labelled
-  controls, and focus traps so the console remains keyboard accessible. [frontend/index.html#L16-L220](../frontend/index.html#L16-L220)
+- [`index.html`](../frontend/index.html) defines landmark regions, the chat
+  surface, and settings drawers using labelled controls and focus guards so the
+  console remains keyboard accessible.
+  [frontend/index.html#L16-L220](../frontend/index.html#L16-L220)
 - [`styles.css`](../frontend/styles.css) implements the responsive shell,
   high-contrast colour system, and focus outlines for dialogs, drawers, and the
-  preview pane. Utility custom properties (`--history-offset`, `--history-height`)
-  are toggled by the runtime to keep the layout stable during resizes. [frontend/styles.css#L1-L200](../frontend/styles.css#L1-L200)
-- [`elements.js`](../frontend/elements.js) centralises DOM lookups so other
-  modules can depend on semantic IDs instead of querying the document directly,
-  reducing the risk of stale selectors. [frontend/elements.js#L1-L120](../frontend/elements.js#L1-L120)
+  preview pane. Custom properties such as `--history-offset` keep the layout
+  stable during resizes. [frontend/styles.css#L1-L220](../frontend/styles.css#L1-L220)
+- [`elements.js`](../frontend/elements.js) centralises DOM lookups so feature
+  modules depend on semantic IDs rather than querying the document directly,
+  reducing the risk of stale selectors.
+  [frontend/elements.js#L1-L37](../frontend/elements.js#L1-L37)
 
 ## Application composition
-- [`app.js`](../frontend/app.js) orchestrates event wiring: it loads stored
-  conversations, initialises preview controls, binds history layout observers,
-  and delegates actions (send, regenerate, branch, open editor) to specialised
-  helpers. [frontend/app.js#L1-L260](../frontend/app.js#L1-L260)
-- The module imports focused utilities for rendering (`previews.js`),
-  conversation state (`conversationState.js`), configuration (`config.js`), and
-  editing (`editor.js`), keeping the main file a coordinator rather than a data
-  store. [frontend/app.js#L21-L80](../frontend/app.js#L21-L80)
-- UI state (active conversation, pending messages, history layout measurements)
-  is tracked through pure functions so rerenders remain predictable and
-  testable. [frontend/app.js#L262-L720](../frontend/app.js#L262-L720)
+- [`app/index.js`](../frontend/app/index.js) orchestrates history layout,
+  streaming, uploads, configuration drawers, and conversation rendering. It wires
+  together specialised controllers and keeps the main file a coordinator rather
+  than a data store. [frontend/app/index.js#L1-L947](../frontend/app/index.js#L1-L947)
+- Supporting modules include [`historyLayout.js`](../frontend/app/historyLayout.js)
+  for dynamic sidebar sizing, [`messageRenderer.js`](../frontend/app/messageRenderer.js)
+  for DOM updates, and [`conversationPanel.js`](../frontend/app/conversationPanel.js)
+  for session switching. [frontend/app/historyLayout.js#L1-L90](../frontend/app/historyLayout.js#L1-L90)
+  [frontend/app/messageRenderer.js#L1-L410](../frontend/app/messageRenderer.js#L1-L410)
+  [frontend/app/conversationPanel.js#L1-L236](../frontend/app/conversationPanel.js#L1-L236)
+- [`streamingController.js`](../frontend/app/streamingController.js) connects the
+  SSE endpoint to live message rendering, tool telemetry cards, and reasoning
+  transcripts. [frontend/app/streamingController.js#L1-L183](../frontend/app/streamingController.js#L1-L183)
 
-## Conversation state and branching
+## Conversation state and persistence
 - [`conversationState.js`](../frontend/conversationState.js) owns the in-memory
-  model: it persists conversations, message branches, and selection indices,
-  generates stable IDs, and keeps storage snapshots in sync. [frontend/conversationState.js#L1-L260](../frontend/conversationState.js#L1-L260)
-- Branch management utilities (`ensureBranchBaseline`, `commitBranchTransition`,
-  `captureBranchSelections`) capture before/after snapshots so users can explore
-  alternative replies without losing history. [frontend/conversationState.js#L60-L200](../frontend/conversationState.js#L60-L200)
-- [`storage.js`](../frontend/storage.js) guards `localStorage` access, falling
-  back gracefully when the environment disallows persistence. [frontend/storage.js#L1-L36](../frontend/storage.js#L1-L36)
+  model, snapshots conversation branches, normalises previews/workspace metadata,
+  and schedules background saves to the server-side store.
+  [frontend/conversationState.js#L1-L810](../frontend/conversationState.js#L1-L810)
+- [`conversationApi.js`](../frontend/conversationApi.js) provides fetch helpers
+  for listing, updating, and deleting conversations via the REST API, keeping the
+  persistence layer encapsulated. [frontend/conversationApi.js#L1-L25](../frontend/conversationApi.js#L1-L25)
+- Branch utilities (`ensureBranchBaseline`, `commitBranchTransition`,
+  `syncActiveBranchSnapshots`) capture before/after snapshots so users can explore
+  alternative replies without losing history.
+  [frontend/conversationState.js#L373-L492](../frontend/conversationState.js#L373-L492)
 
 ## Networking and client identity
 - [`utils.js`](../frontend/utils.js) issues authenticated requests: `fetchJson`
-  injects the caller’s `client_id` into headers and URLs, handles JSON parsing,
-  and normalises errors for user-friendly toasts. [frontend/utils.js#L1-L120](../frontend/utils.js#L1-L120)
-- The helper also generates and stores `client_id` values, syncing cookies and
-  `localStorage` so multiple tabs share the same backend session. [frontend/utils.js#L30-L90](../frontend/utils.js#L30-L90)
-- [`config.js`](../frontend/config.js) builds on these utilities to populate and
-  submit the model configuration drawer, redacting API keys after each save. [frontend/config.js#L1-L110](../frontend/config.js#L1-L110)
+  and `postFormData` inject the caller’s `client_id` into headers and URLs, while
+  `streamJson` handles SSE parsing and error propagation.
+  [frontend/utils.js#L136-L288](../frontend/utils.js#L136-L288)
+- The helper also generates and stores client identifiers across cookies and
+  `localStorage`, ensuring multiple tabs reuse the same backend session.
+  [frontend/utils.js#L1-L134](../frontend/utils.js#L1-L134)
+
+## File uploads and streaming
+- Upload workflows live in [`app/index.js`](../frontend/app/index.js), which
+  enforces size/count limits, posts `FormData` to `/api/session/files`, and merges
+  summaries into the chat timeline. [frontend/app/index.js#L171-L302](../frontend/app/index.js#L171-L302)
+- Streaming responses use the SSE helper plus
+  [`streamingController.js`](../frontend/app/streamingController.js) to append
+  incremental tokens and tool status cards before finalising the assistant
+  message. [frontend/app/streamingController.js#L118-L183](../frontend/app/streamingController.js#L118-L183)
 
 ## Previews and telemetry
 - [`previews.js`](../frontend/previews.js) renders web iframes, slide decks, and
   the model log timeline. It normalises backend payloads, manages sandbox modes,
-  and caps telemetry history for readability. [frontend/previews.js#L1-L200](../frontend/previews.js#L1-L200)
-- Preview controls expose actions such as opening deployments in a new tab or
-  toggling slide carousel mode, keeping the insight column interactive without
-  coupling it to chat rendering. [frontend/previews.js#L200-L360](../frontend/previews.js#L200-L360)
+  and caps telemetry history for readability.
+  [frontend/previews.js#L1-L200](../frontend/previews.js#L1-L200)
+- Preview controls expose actions such as opening deployments or toggling slide
+  carousel mode, keeping the insight column interactive without coupling it to
+  chat rendering. [frontend/previews.js#L200-L328](../frontend/previews.js#L200-L328)
 
 ## Configuration and message editing
-- [`config.js`](../frontend/config.js) pairs service-specific inputs with status
-  messaging so operators know when credentials were loaded, saved, or require
-  re-entry. [frontend/config.js#L14-L110](../frontend/config.js#L14-L110)
-- [`editor.js`](../frontend/editor.js) wraps the Toast UI Markdown editor in an
-  accessible dialog, handling focus management, keyboard shortcuts, and async
-  resolution so chat regeneration can reuse user-edited prompts. [frontend/editor.js#L1-L160](../frontend/editor.js#L1-L160)
+- [`config.js`](../frontend/config.js) loads and submits model configuration,
+  displays status feedback, and redacts API keys after each save.
+  [frontend/config.js#L1-L109](../frontend/config.js#L1-L109)
+- [`app/editingController.js`](../frontend/app/editingController.js) manages
+  inline message editing, form state, and branch updates so regenerated replies
+  remain consistent. [frontend/app/editingController.js#L1-L353](../frontend/app/editingController.js#L1-L353)
 - [`messageActionIcons.js`](../frontend/messageActionIcons.js) and
   [`markdown.js`](../frontend/markdown.js) encapsulate button cloning and secure
-  markdown rendering, reducing duplication when extending the chat UI. [frontend/messageActionIcons.js#L1-L120](../frontend/messageActionIcons.js#L1-L120) [frontend/markdown.js#L1-L160](../frontend/markdown.js#L1-L160)
+  Markdown rendering, reducing duplication when extending the chat UI.
+  [frontend/messageActionIcons.js#L1-L23](../frontend/messageActionIcons.js#L1-L23)
+  [frontend/markdown.js#L1-L35](../frontend/markdown.js#L1-L35)
 
 ## Extending the UI
 
 When adding new frontend capabilities:
 
-1. Update `conversationState.js` (and its storage schema) alongside any new
-   state shape to keep persistence deterministic.
-2. Route network requests through `fetchJson` so client identifiers and error
-   handling stay consistent.
+1. Update `conversationState.js` (and its persistence schema) alongside any new
+   state shape to keep storage deterministic.
+2. Route network requests through `fetchJson`/`streamJson` so client identifiers
+   and error handling stay consistent.
 3. Extend `previews.js` when introducing new artefact types; prefer injecting
    metadata via the backend rather than parsing DOM content.
 4. Keep accessibility guards in sync—update `elements.js`, ARIA labels in
-   `index.html`, and focus logic in `app.js`/`editor.js` as new controls appear.
+   `index.html`, and focus logic in the relevant controllers as new controls
+   appear.

--- a/docs/session_tree.md
+++ b/docs/session_tree.md
@@ -9,44 +9,59 @@ and audit multi-turn projects without losing context.
 1. **Root node – Session metadata.** `SessionState.boot()` seeds the tree with the
    welcome message, workspace descriptors, and virtual machine summary. Resetting
    history or the workspace clears this root and triggers a fresh initialisation
-   on the next request. [src/okcvm/session.py#L372-L403](../src/okcvm/session.py#L372-L403)
+   on the next request. [src/okcvm/session.py#L521-L553](../src/okcvm/session.py#L521-L553)
 2. **Conversation nodes – Message history.** `VirtualMachine.record_history_entry`
    generates deterministic IDs (e.g. `okcvm-12ab34cd-0001`) for each exchange,
    storing message content, tool traces, and metadata. `/api/session/history/{id}`
-   returns any node so the frontend can render branches and tool details. [src/okcvm/vm.py#L58-L178](../src/okcvm/vm.py#L58-L178) [src/okcvm/api/main.py#L257-L309](../src/okcvm/api/main.py#L257-L309)
+   returns any node so the frontend can render branches and tool details.
+   [src/okcvm/vm.py#L229-L255](../src/okcvm/vm.py#L229-L255)
+   [src/okcvm/api/main.py#L595-L606](../src/okcvm/api/main.py#L595-L606)
 3. **Artefact nodes – Tool outputs.** When the agent calls a tool, the input,
    output, and status are persisted alongside the message so deployments, slide
-   decks, and files appear as children in the tree for later inspection. [src/okcvm/vm.py#L118-L178](../src/okcvm/vm.py#L118-L178)
+   decks, and files appear as children in the tree for later inspection.
+   [src/okcvm/session.py#L277-L519](../src/okcvm/session.py#L277-L519)
 
 ## Snapshot workflow
 
 - `SessionState.respond()` labels each snapshot using the user prompt, then calls
   `workspace.state.snapshot()` to commit filesystem changes. The response embeds
   the commit hash, deduplicated artefacts, and recent history so the UI can
-  annotate the timeline. [src/okcvm/session.py#L94-L279](../src/okcvm/session.py#L94-L279) [src/okcvm/workspace.py#L120-L162](../src/okcvm/workspace.py#L120-L162)
+  annotate the timeline. [src/okcvm/session.py#L277-L519](../src/okcvm/session.py#L277-L519)
+  [src/okcvm/workspace.py#L112-L207](../src/okcvm/workspace.py#L112-L207)
 - `SessionState.restore_workspace()` applies `git reset --hard` to a requested
   hash and refreshes the workspace metadata returned to the client. Errors bubble
-  up as `WorkspaceStateError`, which the API converts to HTTP 400 responses. [src/okcvm/session.py#L180-L207](../src/okcvm/session.py#L180-L207) [src/okcvm/workspace.py#L156-L167](../src/okcvm/workspace.py#L156-L167) [src/okcvm/api/main.py#L283-L309](../src/okcvm/api/main.py#L283-L309)
+  up as `WorkspaceStateError`, which the API converts to HTTP 400 responses.
+  [src/okcvm/session.py#L571-L588](../src/okcvm/session.py#L571-L588)
+  [src/okcvm/api/main.py#L797-L845](../src/okcvm/api/main.py#L797-L845)
 
 ## Linking workspaces and history
 
 - Each history node references the active workspace ID and mount paths via
   `VirtualMachine.describe()`. `/api/session/info` exposes these values so the UI
-  can show the correct sandbox when operators jump between branches. [src/okcvm/vm.py#L158-L207](../src/okcvm/vm.py#L158-L207) [src/okcvm/api/main.py#L233-L256](../src/okcvm/api/main.py#L233-L256)
+  can show the correct sandbox when operators jump between branches.
+  [src/okcvm/vm.py#L203-L256](../src/okcvm/vm.py#L203-L256)
+  [src/okcvm/api/main.py#L582-L594](../src/okcvm/api/main.py#L582-L594)
 - Tool implementations receive the injected `WorkspaceManager`, write outputs to
   namespaced directories (e.g. `deployments/`, `generated_slides/`), and include
-  session IDs in their metadata for cross-branch auditing. [src/okcvm/tools/deployment.py#L70-L208](../src/okcvm/tools/deployment.py#L70-L208) [src/okcvm/tools/slides.py#L12-L78](../src/okcvm/tools/slides.py#L12-L78)
+  session IDs in their metadata for cross-branch auditing.
+  [src/okcvm/tools/deployment.py#L118-L320](../src/okcvm/tools/deployment.py#L118-L320)
+  [src/okcvm/tools/slides.py#L1-L108](../src/okcvm/tools/slides.py#L1-L108)
 - URLs returned to the frontend carry the associated `client_id`, preventing
-  cross-session leakage when deployments are opened in new tabs. [src/okcvm/session.py#L94-L240](../src/okcvm/session.py#L94-L240) [src/okcvm/api/main.py#L146-L209](../src/okcvm/api/main.py#L146-L209)
+  cross-session leakage when deployments are opened in new tabs.
+  [src/okcvm/session.py#L239-L276](../src/okcvm/session.py#L239-L276)
+  [src/okcvm/api/main.py#L525-L580](../src/okcvm/api/main.py#L525-L580)
 
 ## Reset and cleanup
 
 1. **Selective rollback.** Calling `/api/session/workspace/restore` rewinds the
    filesystem to a chosen snapshot but keeps the chat history intact, enabling
-   experimentation without losing conversation branches. [src/okcvm/api/main.py#L283-L309](../src/okcvm/api/main.py#L283-L309)
+   experimentation without losing conversation branches.
+   [src/okcvm/api/main.py#L829-L845](../src/okcvm/api/main.py#L829-L845)
 2. **Full reset.** `/api/session/history` with DELETE wipes the VM history and
    removes the workspace directory. The next interaction reinitialises the root
-   node and provisions a new sandbox. [src/okcvm/api/main.py#L267-L282](../src/okcvm/api/main.py#L267-L282) [src/okcvm/session.py#L405-L417](../src/okcvm/session.py#L405-L417)
+   node and provisions a new sandbox.
+   [src/okcvm/api/main.py#L783-L809](../src/okcvm/api/main.py#L783-L809)
+   [src/okcvm/session.py#L555-L569](../src/okcvm/session.py#L555-L569)
 
 ## Best practices
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -9,53 +9,63 @@ operators can roll back to previous states with confidence.
 1. **Mount points.** `WorkspaceManager` generates a random mount name (e.g.
    `/mnt/okcvm-12ab34cd/`) and prepares an internal root with `mnt/`, `output/`,
    and `tmp/` subdirectories for user-visible files, tool outputs, and temporary
-   artefacts. [src/okcvm/workspace.py#L32-L118](../src/okcvm/workspace.py#L32-L118)
+   artefacts. [src/okcvm/workspace.py#L225-L332](../src/okcvm/workspace.py#L225-L332)
 2. **Path dataclass.** `WorkspacePaths` stores the session ID, public mount paths,
    and absolute filesystem locations so APIs and logs can describe artefacts
-   without leaking internal directory layouts. [src/okcvm/workspace.py#L168-L211](../src/okcvm/workspace.py#L168-L211)
+   without leaking internal directory layouts.
+   [src/okcvm/workspace.py#L212-L224](../src/okcvm/workspace.py#L212-L224)
 3. **Cleanup.** `WorkspaceManager.cleanup()` safely removes the internal root when
-   sessions reset, ignoring missing directories to keep operations idempotent. [src/okcvm/workspace.py#L228-L264](../src/okcvm/workspace.py#L228-L264)
+   sessions reset, ignoring missing directories to keep operations idempotent.
+   [src/okcvm/workspace.py#L333-L370](../src/okcvm/workspace.py#L333-L370)
 
 ## Path resolution and sandboxing
 
-- All user-supplied paths flow through `WorkspaceManager.resolve()`, which normalises
-  separators, rewrites absolute paths into the session root, and prevents escapes
-  above the workspace directory by raising `WorkspaceError`. [src/okcvm/workspace.py#L212-L264](../src/okcvm/workspace.py#L212-L264)
+- All user-supplied paths flow through `WorkspaceManager.resolve()`, which
+  normalises separators, rewrites absolute paths into the session root, and
+  prevents escapes above the workspace directory by raising `WorkspaceError`.
+  [src/okcvm/workspace.py#L293-L321](../src/okcvm/workspace.py#L293-L321)
 - `adapt_prompt()` replaces legacy mount references (e.g. `/mnt/okcomputer/`) in
   the system prompt so the agent always receives the current session-specific
-  paths. [src/okcvm/workspace.py#L266-L281](../src/okcvm/workspace.py#L266-L281)
+  paths. [src/okcvm/workspace.py#L323-L331](../src/okcvm/workspace.py#L323-L331)
 
 ## Git-backed snapshots
 
 - `GitWorkspaceState` initialises a repository inside the workspace, sets isolated
   Git environment variables, and provides `snapshot()` / `restore()` helpers.
   Environments without Git fall back to a null implementation that disables
-  snapshots but keeps the sandbox usable. [src/okcvm/workspace.py#L44-L167](../src/okcvm/workspace.py#L44-L167)
+  snapshots but keeps the sandbox usable.
+  [src/okcvm/workspace.py#L47-L207](../src/okcvm/workspace.py#L47-L207)
 - Snapshots stage all files, commit with a label derived from the conversation,
-  and return metadata (hash, message, timestamp) for the session tree. [src/okcvm/workspace.py#L120-L162](../src/okcvm/workspace.py#L120-L162)
+  and return metadata (hash, message, timestamp) for the session tree.
+  [src/okcvm/workspace.py#L119-L158](../src/okcvm/workspace.py#L119-L158)
 - Restoring a snapshot performs `git reset --hard`, cleans untracked files, and
   raises `WorkspaceStateError` when an unknown hash is provided so callers can
-  surface actionable errors. [src/okcvm/workspace.py#L156-L167](../src/okcvm/workspace.py#L156-L167)
+  surface actionable errors. [src/okcvm/workspace.py#L160-L172](../src/okcvm/workspace.py#L160-L172)
 
 ## Session lifecycle integration
 
 1. **Creation.** `SessionState._initialise_vm()` resolves workspace settings from
    the global config, instantiates `WorkspaceManager`, injects it into the tool
-   registry, and prepares the virtual machine for the client. [src/okcvm/session.py#L22-L90](../src/okcvm/session.py#L22-L90)
+   registry, and prepares the virtual machine for the client.
+   [src/okcvm/session.py#L30-L153](../src/okcvm/session.py#L30-L153)
 2. **Response handling.** `SessionState.respond()` generates snapshot labels from
    the latest user message, captures the workspace state, and includes summary
-   metadata in the API response for frontend consumption. [src/okcvm/session.py#L94-L150](../src/okcvm/session.py#L94-L150)
+   metadata in the API response for frontend consumption.
+   [src/okcvm/session.py#L277-L519](../src/okcvm/session.py#L277-L519)
 3. **Reset.** `SessionState.delete_history()` and `SessionState.reset()` call
    `cleanup()` on the workspace, ensuring stale files never leak into new
-   sessions. [src/okcvm/session.py#L152-L207](../src/okcvm/session.py#L152-L207)
+   sessions. [src/okcvm/session.py#L555-L569](../src/okcvm/session.py#L555-L569)
 
 ## API integration
 
 - FastAPI routes list, create, and restore snapshots under `/api/session/workspace/*`,
-  wrapping workspace errors into HTTP 400 responses for clarity. [src/okcvm/api/main.py#L267-L309](../src/okcvm/api/main.py#L267-L309)
+  wrapping workspace errors into HTTP 400 responses for clarity.
+  [src/okcvm/api/main.py#L797-L845](../src/okcvm/api/main.py#L797-L845)
 - Tools that require filesystem access receive the workspace manager via dependency
   injection, guaranteeing their reads/writes stay inside the sandbox and are
-  tracked by subsequent snapshots. [src/okcvm/registry.py#L118-L200](../src/okcvm/registry.py#L118-L200) [src/okcvm/tools/deployment.py#L70-L208](../src/okcvm/tools/deployment.py#L70-L208)
+  tracked by subsequent snapshots.
+  [src/okcvm/registry.py#L1-L175](../src/okcvm/registry.py#L1-L175)
+  [src/okcvm/tools/deployment.py#L118-L320](../src/okcvm/tools/deployment.py#L118-L320)
 
 Treat the workspace as the source of truth for artefacts—tests, deployments, and
 previews all rely on its consistency and isolation guarantees.

--- a/roadmap.md
+++ b/roadmap.md
@@ -6,87 +6,76 @@ living document—update it whenever major capabilities land or priorities shift
 
 ## Recently Delivered
 
-### Production-ready runtime and observability
-- FastAPI now powers the public surface, complete with CORS support, structured
-  request logging, and static hosting for the operator console so deployments are
-  inspectable with minimal configuration. [src/okcvm/api/main.py#L30-L209](src/okcvm/api/main.py#L30-L209)
-- The logging stack wires Rich console handlers and rotating file output, making
-  API and agent traces actionable during incident response. [src/okcvm/logging_utils.py#L1-L115](src/okcvm/logging_utils.py#L1-L115)
+### Streaming-first runtime and operator feedback
+- `/api/chat` now supports server-sent events with incremental tokens, tool status
+  updates, and final payloads. The streaming pipeline relies on
+  `LangChainStreamingHandler` and the frontend controller to surface progress.
+  [src/okcvm/api/main.py#L705-L781](src/okcvm/api/main.py#L705-L781)
+  [src/okcvm/streaming.py#L33-L165](src/okcvm/streaming.py#L33-L165)
+  [frontend/app/streamingController.js#L1-L183](frontend/app/streamingController.js#L1-L183)
+- Structured model logs and telemetry cards are persisted alongside each
+  conversation so operators can audit tool traces without leaving the console.
+  [src/okcvm/session.py#L277-L519](src/okcvm/session.py#L277-L519)
+  [frontend/previews.js#L1-L200](frontend/previews.js#L1-L200)
 
-### Virtual machine orchestration and tooling
-- The LangChain-backed `VirtualMachine` streams conversation history into a tool
-  aware agent executor and records the trace required by the UI’s model log. [src/okcvm/vm.py#L26-L178](src/okcvm/vm.py#L26-L178)
-- `ToolRegistry` loads the canonical tool manifest, injects workspace-aware
-  helpers, and exposes LangChain-compatible wrappers, closing the loop between
-  packaged specifications and runtime behaviour. [src/okcvm/registry.py#L1-L200](src/okcvm/registry.py#L1-L200)
+### Persistent conversation store
+- A SQLAlchemy-backed `ConversationStore` records conversations, workspace
+  metadata, and deployment paths, enabling restore-on-reload behaviour and safe
+  deletion of stale workspaces. [src/okcvm/storage/conversations.py#L81-L318](src/okcvm/storage/conversations.py#L81-L318)
+- REST endpoints expose CRUD operations for the store while the frontend queues
+  saves/deletes in the background to keep UI interactions snappy.
+  [src/okcvm/api/main.py#L525-L580](src/okcvm/api/main.py#L525-L580)
+  [frontend/conversationState.js#L612-L810](frontend/conversationState.js#L612-L810)
 
-### Session isolation and workspace lifecycle
-- Every client receives an isolated `WorkspaceManager` that rewrites prompt
-  mounts, restricts filesystem access, and snapshots state through Git-backed
-  commits for time-travel debugging. [src/okcvm/session.py#L22-L207](src/okcvm/session.py#L22-L207) [src/okcvm/workspace.py#L32-L281](src/okcvm/workspace.py#L32-L281)
-- Snapshot creation, listing, and restoration are exposed as first-class API
-  endpoints so the frontend can drive the session tree UI without bespoke glue
-  code. [src/okcvm/api/main.py#L210-L309](src/okcvm/api/main.py#L210-L309)
-- Artifact metadata, deployment URLs, and slide previews are normalised inside
-  `SessionState.respond`, ensuring previews include a `client_id` and stay
-  deduplicated across tool payloads. [src/okcvm/session.py#L76-L279](src/okcvm/session.py#L76-L279)
+### Workspace uploads and prompt hints
+- Operators can upload reference files directly through the console. The backend
+  enforces per-session limits, stores files in the sandbox, and patches the system
+  prompt with contextual summaries. [src/okcvm/api/main.py#L616-L703](src/okcvm/api/main.py#L616-L703)
+  [src/okcvm/session.py#L96-L157](src/okcvm/session.py#L96-L157)
+  [frontend/app/index.js#L171-L302](frontend/app/index.js#L171-L302)
 
-### Client-scoped orchestration
-- `SessionStore` provisions sessions per `client_id`, while `AppState` exposes
-  the active VM for debugging and tests without sacrificing encapsulation.
-  Cookies, headers, and query parameters all map to the same identifier so tabs
-  from the same browser stay synced. [src/okcvm/api/main.py#L90-L206](src/okcvm/api/main.py#L90-L206)
-- The frontend propagates the identifier automatically when calling the API or
-  loading deployment assets, removing the need for manual wiring when embedding
-  the console. [frontend/utils.js#L1-L120](frontend/utils.js#L1-L120)
-
-### Operator experience and automation
-- A Typer CLI now launches the FastAPI server, validates configuration, and
-  resolves workspace directories before Uvicorn starts, smoothing local and
-  production workflows. [src/okcvm/server.py#L1-L88](src/okcvm/server.py#L1-L88)
-- Configuration dataclasses centralise chat and media credentials, providing
-  atomic updates from YAML, environment variables, or API requests. [src/okcvm/config.py#L25-L227](src/okcvm/config.py#L25-L227)
-
-### Control panel and presentation layer
-- The static frontend now splits responsibilities across focused modules for
-  configuration, conversation state, previews, and utilities while retaining the
-  accessible layout defined in `index.html`. [frontend/index.html#L16-L220](frontend/index.html#L16-L220) [frontend/app.js#L1-L200](frontend/app.js#L1-L200) [frontend/conversationState.js#L1-L240](frontend/conversationState.js#L1-L240)
-- Deployment assets are served directly from per-session directories, and
-  preview frames consume the enriched metadata produced by the backend to keep
-  artefacts, slides, and web content in sync. [src/okcvm/api/main.py#L146-L209](src/okcvm/api/main.py#L146-L209) [frontend/previews.js#L1-L200](frontend/previews.js#L1-L200)
+### Frontend modularisation
+- The console now delegates responsibilities to focused modules for history
+  layout, streaming, uploads, configuration, and conversation persistence, making
+  the UI easier to extend. [frontend/app/index.js#L1-L947](frontend/app/index.js#L1-L947)
+  [frontend/conversationState.js#L1-L810](frontend/conversationState.js#L1-L810)
+- Networking utilities manage `client_id` propagation, SSE parsing, and error
+  handling so new features inherit consistent behaviour.
+  [frontend/utils.js#L136-L288](frontend/utils.js#L136-L288)
 
 ### Quality and safety net
-- The pytest suite exercises API routes, workspace guarantees, and LangChain
-  integration so regressions surface quickly during CI. [tests/test_api_app.py#L1-L145](tests/test_api_app.py#L1-L145) [tests/test_workspace.py#L1-L24](tests/test_workspace.py#L1-L24)
+- New regression suites cover streaming callbacks, storage persistence, and
+  workspace tooling in addition to the existing API and VM scenarios.
+  [tests/test_streaming.py#L1-L110](tests/test_streaming.py#L1-L110)
+  [tests/test_storage_conversations.py#L1-L132](tests/test_storage_conversations.py#L1-L132)
+  [tests/test_workspace.py#L1-L74](tests/test_workspace.py#L1-L74)
 
 ## Active Initiatives
 
-### Streaming and responsiveness
-We are investigating LangChain callback handlers to surface partial assistant
-responses, tool progress, and heartbeat updates to the frontend without waiting
-for the full completion. This requires expanding `VirtualMachine.respond` to
-support incremental yield semantics and adapting the UI to consume a stream.
-
 ### Rich asset representations
-Tool outputs currently ship as raw HTML snippets or file paths. The next sprint
-focuses on producing structured metadata (thumbnails, slide manifests, audio
-waveforms) so the control panel can render immersive previews while remaining
-agnostic of tool specifics.
+We are expanding tool payload schemas with thumbnails, slide manifests, and audio
+metadata so the control panel can render immersive previews without bespoke glue.
+This work touches `SessionState.respond`, deployment helpers, and the preview
+renderer. [src/okcvm/session.py#L277-L519](src/okcvm/session.py#L277-L519)
+[frontend/previews.js#L200-L328](frontend/previews.js#L200-L328)
 
-### Session persistence and collaboration
-With per-client isolation in place, the next milestone is durable storage and
-retention policies so teams can resume workspaces across restarts, expire
-dormant sessions, and intentionally share deployments between operators without
-manual intervention.
+### Collaboration and retention controls
+With the conversation store in place, the next milestone is cross-session
+collaboration: durable retention policies, explicit sharing flows, and import/
+export helpers for downstream tooling. [src/okcvm/storage/conversations.py#L81-L318](src/okcvm/storage/conversations.py#L81-L318)
+[frontend/conversationState.js#L612-L810](frontend/conversationState.js#L612-L810)
+
+### Packaging and distribution
+Package the orchestrator (CLI, FastAPI app, and frontend) as container images and
+Python wheels so operators can deploy OKCVM without cloning the repository.
+[src/okcvm/server.py#L1-L88](src/okcvm/server.py#L1-L88)
+[pyproject.toml#L1-L40](pyproject.toml#L1-L40)
 
 ## Future Exploration
 
-- **Packaging and distribution** – Ship container images and Python wheels that
-  bundle the CLI, FastAPI app, and frontend for zero-effort installation.
-- **Advanced browser automation** – Offer Playwright-backed browsing with
-  resource limits while keeping the deterministic HTTP crawler for offline mode.
-- **Media integrations** – Continue adding reference connectors for speech,
-  sound effects, and ASR providers with consistent secret handling across
-  toolchains.
+- **Advanced browser automation** – Offer Playwright-backed browsing with resource
+  limits while keeping the deterministic HTTP crawler for offline mode.
+- **Media integrations** – Continue adding reference connectors for speech, sound
+  effects, and ASR providers with consistent secret handling across toolchains.
 - **Observability exports** – Push structured traces and workspace events into
   OpenTelemetry so operators can correlate OKCVM activity with external systems.


### PR DESCRIPTION
## Summary
- sync the architecture and backend documentation with the new streaming pipeline, conversation store, and upload workflows
- update the frontend, session tree, and workspace guides to reference the current module structure and APIs
- refresh the English and Chinese roadmaps to capture recently delivered features and active initiatives

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_b_68e246914044832183adb79b6902ed2c