### PR TITLE
Bind workspace state to conversation branches

### DIFF
--- a/docs/session_tree.md
+++ b/docs/session_tree.md
@@ -27,6 +27,9 @@ and audit multi-turn projects without losing context.
 - `SessionState.restore_workspace()` applies `git reset --hard` to a requested
   hash and refreshes the workspace metadata returned to the client. Errors bubble
   up as `WorkspaceStateError`, which the API converts to HTTP 400 responses. [src/okcvm/session.py#L180-L207](../src/okcvm/session.py#L180-L207) [src/okcvm/workspace.py#L156-L167](../src/okcvm/workspace.py#L156-L167) [src/okcvm/api/main.py#L283-L309](../src/okcvm/api/main.py#L283-L309)
+- Each conversation branch stores a dedicated Git branch. When the UI switches
+  branches it calls `/api/session/workspace/restore` with the stored branch
+  name so the sandbox checks out the matching commit automatically. [src/okcvm/workspace.py#L90-L213](../src/okcvm/workspace.py#L90-L213) [src/okcvm/session.py#L548-L586](../src/okcvm/session.py#L548-L586) [frontend/app/index.js#L70-L218](../frontend/app/index.js#L70-L218)
 
 ## Linking workspaces and history
 

--- a/frontend/workspaceApi.js
+++ b/frontend/workspaceApi.js
@@ -1,0 +1,41 @@
+import { fetchJson } from './utils.js';
+
+export async function assignWorkspaceBranch({ branch, snapshotId, checkout = true } = {}) {
+  if (typeof branch !== 'string' || !branch.trim()) {
+    throw new Error('缺少有效的分支名称，无法标记工作区');
+  }
+
+  const payload = { branch: branch.trim() };
+  if (typeof snapshotId === 'string' && snapshotId.trim()) {
+    payload.snapshot_id = snapshotId.trim();
+  }
+  payload.checkout = Boolean(checkout);
+
+  return fetchJson('/api/session/workspace/branch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function restoreWorkspace({ branch, snapshotId, checkout = true } = {}) {
+  const payload = {};
+  if (typeof branch === 'string' && branch.trim()) {
+    payload.branch = branch.trim();
+  }
+  if (typeof snapshotId === 'string' && snapshotId.trim()) {
+    payload.snapshot_id = snapshotId.trim();
+  }
+
+  if (!payload.branch && !payload.snapshot_id) {
+    throw new Error('缺少快照或分支信息，无法恢复工作区');
+  }
+
+  payload.checkout = Boolean(checkout);
+
+  return fetchJson('/api/session/workspace/restore', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}


### PR DESCRIPTION
## Summary
- add REST support for assigning and restoring workspace Git branches alongside snapshots
- track workspace checkpoints per conversation branch and call the new APIs when branching or navigating in the UI
- document the branch workflow and cover it with new API tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e247fb0ec8832192f53a5df3f71515